### PR TITLE
Feat/card actions

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -153,6 +153,17 @@ MULTIPLE_ALLOWED_PROCESS_NAMES = [
     REGEX_PROCESS,
 ]
 
+FlagValueType = Literal[0, 1, 2, 3, 4, 5, 6, 7]
+
+
+class CardAction(TypedDict):
+    guid: str
+    card_type_name: str
+    change_deck: Optional[str]
+    set_flag: Optional[FlagValueType]
+    suspend: Optional[bool]
+    bury: Optional[bool]
+
 
 class CopyFieldToField(TypedDict):
     guid: str
@@ -235,6 +246,7 @@ class CopyDefinition(TypedDict):
     field_to_field_defs: list[CopyFieldToField]
     field_to_file_defs: list[CopyFieldToFile]
     field_to_variable_defs: list[CopyFieldToVariable]
+    card_actions: Optional[list[CardAction]]
     add_tags: Optional[str]
     remove_tags: Optional[str]
     only_copy_into_decks: Optional[str]

--- a/configuration.py
+++ b/configuration.py
@@ -412,6 +412,13 @@ class Config:
         self.data["copy_definitions"].append(definition)
         self.save()
 
+    def insert_definition_at_index(self, index: int, definition: CopyDefinition):
+        """Insert a definition at a specific index in the list"""
+        if "guid" not in definition:
+            definition["guid"] = str(uuid.uuid4())
+        self.data["copy_definitions"].insert(index, definition)
+        self.save()
+
     def remove_definition_by_name(self, name: str):
         definition = self.get_definition_by_name(name)
         if definition is None:

--- a/configuration.py
+++ b/configuration.py
@@ -155,6 +155,8 @@ MULTIPLE_ALLOWED_PROCESS_NAMES = [
 
 FlagValueType = Literal[0, 1, 2, 3, 4, 5, 6, 7]
 
+CARD_TYPE_SEPARATOR = "<::>"
+
 
 class CardAction(TypedDict):
     guid: str

--- a/hooks/note_hooks.py
+++ b/hooks/note_hooks.py
@@ -191,12 +191,12 @@ def run_copy_fields_on_review(card: Card):
             logger=logger,
         )
     # Replace the card in copied_into_cards with the merged version
-    for i, c in enumerate(copied_into_cards):
-        if c.id == card.id:
-            merge_cards(card, c)
-            # Remove the duplicate card from the list
-            copied_into_cards.pop(i)
-            break
+    # Find and merge with the matching card, if present
+    matching_card = next((c for c in copied_into_cards if c.id == card.id), None)
+    if matching_card is not None:
+        merge_cards(card, matching_card)
+    # Remove any card with the same id as the reviewed card
+    copied_into_cards = [c for c in copied_into_cards if c.id != card.id]
     # Ensure the reviewed card is always updated
     copied_into_cards.append(card)
     if has_definitions_to_process_on_sync:

--- a/hooks/note_hooks.py
+++ b/hooks/note_hooks.py
@@ -194,7 +194,11 @@ def run_copy_fields_on_review(card: Card):
     for i, c in enumerate(copied_into_cards):
         if c.id == card.id:
             merge_cards(card, c)
-            copied_into_cards[i] = card
+            # Remove the duplicate card from the list
+            copied_into_cards.pop(i)
+            break
+    # Ensure the reviewed card is always updated
+    copied_into_cards.append(card)
     if has_definitions_to_process_on_sync:
         # In order to not have on_sync definitions run twice, we'll set a different fc value
         write_custom_data(card, key="fc", value=-1)

--- a/hooks/note_hooks.py
+++ b/hooks/note_hooks.py
@@ -203,6 +203,8 @@ def run_copy_fields_on_review(card: Card):
             if c.id == card.id:
                 # Merge all changes to the reviewed card so that the final update_card call
                 # doesn't overwrite the changes done here
+                # Note, edited attribute is not merged as it's not a real card attribute, we don't
+                # need it after this, as edit the card regardless
                 merge_cards(card, c)
             del c.edited
         # update_card adds a new undo entry Update cards

--- a/hooks/sync_hook.py
+++ b/hooks/sync_hook.py
@@ -112,7 +112,7 @@ def remote_changes_copy_definitions(sync_result: SyncResult) -> None:
 
     def show_tooltip_on_done():
         # Showing the tooltip right after the op finishes results in it being closed right
-        # away, likely becayse the progress dialog is still open. So we use a single shot timer
+        # away, likely because the progress dialog is still open. So we use a single shot timer
         # to delay the tooltip.
         mw.progress.single_shot(100, lambda: show_result_tooltip(sync_result))
 

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1084,7 +1084,7 @@ def copy_into_single_note(
                 card.queue = -1
             else:
                 card.queue = card.type
-        if bury_card in [True, False] and not suspend_card:
+        if bury_card in [True, False] and suspend_card != True:
             # Card cannot be buried if it is suspended
             if bury_card:
                 card.queue = -2

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1076,7 +1076,7 @@ def copy_into_single_note(
         suspend_card = card_action.get("suspend", None)
         bury_card = card_action.get("bury", None)
         set_flag = card_action.get("set_flag", None)
-        if change_deck != "-" and change_deck is not None:
+        if change_deck not in [None, "-"]:
             move_card_to_deck(card, change_deck, logger=logger)
         if suspend_card in [True, False]:
             # see pylib/anki/cards.py for queue values

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -383,7 +383,7 @@ def copy_fields(
             logger.error("Error in copy fields: No definitions given")
             return CacheResults(result_text="", changes=None)
 
-        copied_into_cards: list[Card] = []
+        copied_into_cards_dict: dict[int, Card] = {}
         copied_into_notes: list[Note] = []
         # If an undo_entry isn't passed, create one
         nonlocal undo_entry
@@ -412,7 +412,7 @@ def copy_fields(
                 ),
                 logger=logger,
                 is_sync=is_sync,
-                copied_into_cards=copied_into_cards,
+                copied_into_cards_dict=copied_into_cards_dict,
                 copied_into_notes=copied_into_notes,
                 results=results,
                 field_only=field_only,
@@ -423,13 +423,23 @@ def copy_fields(
             # Because of this, if multiple ops use the same note data as a source, the final result
             # depends on the order of the ops
             mw.col.update_notes(copied_into_notes)
+            # Update all edited cards so far, then remove the edited flag
+            # This must be done after each operation, so that if subsequent use card data as source,
+            # the final result depends on the order of the ops
+            edited_cards = [
+                card
+                for card in copied_into_cards_dict.values()
+                if hasattr(card, "edited") and card.edited
+            ]
+            mw.col.update_cards(edited_cards)
             # undo_entry has to be updated after every undoable op or the last_step will
             # increment causing an "target undo op not found" error!
             results.changes = mw.col.merge_undo_entries(undo_entry)
             if mw.progress.want_cancel():
                 break
         if is_sync:
-            # Update card custom-data after all ops are complete
+            # Update all card custom-data after all ops are complete
+            copied_into_cards = list(copied_into_cards_dict.values())
             for card in copied_into_cards:
                 write_custom_data(card, key="fc", value=1)
             mw.col.update_cards(copied_into_cards)
@@ -449,7 +459,7 @@ def copy_fields(
 
 def copy_fields_in_background(
     copy_definition: CopyDefinition,
-    copied_into_cards: list[Card],
+    copied_into_cards_dict: dict[int, Card],
     copied_into_notes: list[Note],
     results: CacheResults,
     is_sync: Optional[bool] = False,
@@ -461,7 +471,7 @@ def copy_fields_in_background(
     """
     Function run to copy stuff into many notes at once.
     :param copy_definition: The definition of what to copy, includes process chains
-    :param copied_into_cards: An initially empty list of cards that will be appended to with the
+    :param copied_into_cards_dict: An initially empty dictionary of cards that will be appended to with the
         cards of the notes that were copied into
     :param copied_into_notes: An initially empty list of notes that will be appended to with the
         notes that were copied into
@@ -561,7 +571,7 @@ def copy_fields_in_background(
             trigger_note=note,
             is_sync=is_sync,
             copied_into_notes=copied_into_notes,
-            copied_into_cards=copied_into_cards,
+            copied_into_cards_dict=copied_into_cards_dict,
             field_only=field_only,
             logger=logger,
             file_cache=file_cache,
@@ -711,7 +721,7 @@ def copy_for_single_trigger_note(
     trigger_note: Note,
     is_sync: Optional[bool] = False,
     copied_into_notes: Optional[list[Note]] = None,
-    copied_into_cards: Optional[list[Card]] = None,
+    copied_into_cards_dict: Optional[dict[int, Card]] = None,
     field_only: Optional[str] = None,
     deck_id: Optional[int] = None,
     logger: Logger = Logger("error"),
@@ -726,8 +736,8 @@ def copy_for_single_trigger_note(
     :param copied_into_notes: A list of notes that were copied into, to be appended to
         with the destination notes. Can be omitted, if it's not necessary to run
         mw.col.update_notes(copied_into_notes) after the operation
-    :param copied_into_cards: A list of cards that were copied into, to be appended to
-        with the cards of the destination notes. Can be omitted, if it's not necessary to run
+    :param copied_into_cards_dict: A dictionary of cards that were copied into, keyed by card ID,
+        to be appended to with the cards of the destination notes. Can be omitted, if it's not necessary to run
         mw.col.update_cards(copied_into_cards) after the operation
     :param field_only: Optional field to limit copying to. Used when copying is applied
       in the note editor
@@ -883,8 +893,10 @@ def copy_for_single_trigger_note(
                 )
             if copied_into_notes is not None and copied_into_dest_note:
                 copied_into_notes.append(destination_note)
-            if copied_into_cards is not None and dest_note_cards:
-                copied_into_cards.extend(dest_note_cards)
+            if copied_into_cards_dict is not None and dest_note_cards:
+                # Add cards to the dict so they can be updated later
+                for new_card in dest_note_cards:
+                    copied_into_cards_dict[new_card.id] = new_card
         except CopyFailedException:
             return False
 
@@ -1053,7 +1065,7 @@ def copy_into_single_note(
     dest_note_type = destination_note.note_type()
     for card_action in card_actions:
         # The card_type_name contains the note type and card type separated by CARD_TYPE_SEPARATOR
-        note_type_and_card_type = card_action.get("card_type_name ", "")
+        note_type_and_card_type = card_action.get("card_type_name", "")
         if CARD_TYPE_SEPARATOR not in note_type_and_card_type:
             logger.error(
                 f"Error in copy fields: Invalid card type name '{note_type_and_card_type}'"
@@ -1078,12 +1090,15 @@ def copy_into_single_note(
         set_flag = card_action.get("set_flag", None)
         if change_deck not in [None, "-"]:
             move_card_to_deck(card, change_deck, logger=logger)
+            print(f"Moved card id {card.id} to deck '{change_deck}', did={card.odid or card.did}")
+            card.edited = True
         if suspend_card in [True, False]:
             # see pylib/anki/cards.py for queue values
             if suspend_card:
                 card.queue = -1
             else:
                 card.queue = card.type
+            card.edited = True
         if bury_card in [True, False] and card.queue != -1:
             # Card cannot be buried, if it is suspended
             # To bury a suspended card, it must first be unsuspended with a suspend action
@@ -1091,8 +1106,10 @@ def copy_into_single_note(
                 card.queue = -2
             else:
                 card.queue = card.type
+            card.edited = True
         if isinstance(set_flag, int) and 0 <= set_flag <= 7:
             card.set_user_flag(set_flag)
+            card.edited = True
     return (modified_dest_note, wrote_to_file, dest_note_cards)
 
 

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -431,6 +431,8 @@ def copy_fields(
                 for card in copied_into_cards_dict.values()
                 if hasattr(card, "edited") and card.edited
             ]
+            for card in edited_cards:
+                del card.edited
             mw.col.update_cards(edited_cards)
             # undo_entry has to be updated after every undoable op or the last_step will
             # increment causing an "target undo op not found" error!

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1073,8 +1073,8 @@ def copy_into_single_note(
         if card_action is None:
             continue
         change_deck = card_action.get("change_deck", None)
-        suspend_card = card_action.get("suspend_card", None)
-        bury_card = card_action.get("bury_card", None)
+        suspend_card = card_action.get("suspend", None)
+        bury_card = card_action.get("bury", None)
         set_flag = card_action.get("set_flag", None)
         if change_deck != "-" and change_deck is not None:
             move_card_to_deck(card, change_deck, logger=logger)

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1090,7 +1090,6 @@ def copy_into_single_note(
         set_flag = card_action.get("set_flag", None)
         if change_deck not in [None, "-"]:
             move_card_to_deck(card, change_deck, logger=logger)
-            print(f"Moved card id {card.id} to deck '{change_deck}', did={card.odid or card.did}")
             card.edited = True
         if suspend_card in [True, False]:
             # see pylib/anki/cards.py for queue values

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1053,7 +1053,7 @@ def copy_into_single_note(
     dest_note_type = destination_note.note_type()
     for card_action in card_actions:
         # The card_type_name contains the note type and card type separated by "::"
-        note_type_and_card_type = card_action.get("card_type_name ", "")
+        note_type_and_card_type = card_action.get("card_type_name", "")
         if "::" not in note_type_and_card_type:
             logger.error(
                 f"Error in copy fields: Invalid card type name '{note_type_and_card_type}'"

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1090,7 +1090,7 @@ def copy_into_single_note(
                 card.queue = -2
             else:
                 card.queue = card.type
-        if 0 <= set_flag <= 7:
+        if isinstance(set_flag, int) and 0 <= set_flag <= 7:
             card.set_user_flag(set_flag)
     return (modified_dest_note, wrote_to_file, dest_note_cards)
 

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1084,8 +1084,9 @@ def copy_into_single_note(
                 card.queue = -1
             else:
                 card.queue = card.type
-        if bury_card in [True, False] and suspend_card is not True:
-            # Card cannot be buried if it is suspended
+        if bury_card in [True, False] and card.queue != -1:
+            # Card cannot be buried, if it is suspended
+            # To bury a suspended card, it must first be unsuspended with a suspend action
             if bury_card:
                 card.queue = -2
             else:

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1052,9 +1052,9 @@ def copy_into_single_note(
     card_actions_by_template_name = {}
     dest_note_type = destination_note.note_type()
     for card_action in card_actions:
-        # The card_type_name contains the note type and card type separated by "::"
-        note_type_and_card_type = card_action.get("card_type_name", "")
-        if "::" not in note_type_and_card_type:
+        # The card_type_name contains the note type and card type separated by CARD_TYPE_SEPARATOR
+        note_type_and_card_type = card_action.get("card_type_name ", "")
+        if CARD_TYPE_SEPARATOR not in note_type_and_card_type:
             logger.error(
                 f"Error in copy fields: Invalid card type name '{note_type_and_card_type}'"
             )
@@ -1084,7 +1084,7 @@ def copy_into_single_note(
                 card.queue = -1
             else:
                 card.queue = card.type
-        if bury_card in [True, False] and suspend_card != True:
+        if bury_card in [True, False] and suspend_card is not True:
             # Card cannot be buried if it is suspended
             if bury_card:
                 card.queue = -2

--- a/ui/card_actions_editor.py
+++ b/ui/card_actions_editor.py
@@ -117,17 +117,14 @@ class CardActionsEditor(QWidget):
 
     def set_description(self):
         """Update the description label based on the current copy mode and direction"""
-        self.description_label.setText(
-            base_description
-            + (
-                source_to_destinations_description
-                if (
-                    self.state.copy_mode == COPY_MODE_ACROSS_NOTES
-                    and self.state.copy_direction == DIRECTION_SOURCE_TO_DESTINATIONS
-                )
-                else destination_to_sources_description
-            )
-        )
+        if self.state.copy_mode == COPY_MODE_ACROSS_NOTES:
+            if self.state.copy_direction == DIRECTION_SOURCE_TO_DESTINATIONS:
+                description = source_to_destinations_description
+            else:
+                description = destination_to_sources_description
+        else:  # COPY_MODE_WITHIN_NOTE
+            description = ""  # or a specific description for within-note mode
+        self.description_label.setText(base_description + description)
 
     def initialize_ui_state(self):
         """Perform expensive UI state initialization when component is first shown"""

--- a/ui/card_actions_editor.py
+++ b/ui/card_actions_editor.py
@@ -219,7 +219,7 @@ class CardActionsEditor(QWidget):
             available_templates = []
             for template in templates:
                 template_name = template.get("name", "")
-                item_text = f"{model_name}::{template_name}"
+                item_text = f"{model_name}{CARD_TYPE_SEPARATOR}{template_name}"
                 # Only add if not already in card_actions
                 if item_text not in self.card_actions:
                     available_templates.append(item_text)

--- a/ui/card_actions_editor.py
+++ b/ui/card_actions_editor.py
@@ -1,0 +1,499 @@
+from typing import Optional, Dict
+import uuid
+
+from aqt import mw
+from aqt.qt import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QFrame,
+    QLabel,
+    QFormLayout,
+    QPushButton,
+    QComboBox,
+    QButtonGroup,
+    QRadioButton,
+    qtmajor,
+)
+
+if qtmajor > 5:
+    QFrameStyledPanel = QFrame.Shape.StyledPanel
+    QFrameShadowRaised = QFrame.Shadow.Raised
+else:
+    QFrameStyledPanel = QFrame.StyledPanel  # type: ignore
+    QFrameShadowRaised = QFrame.Raised  # type: ignore
+
+from ..configuration import (
+    COPY_MODE_ACROSS_NOTES,
+    DIRECTION_SOURCE_TO_DESTINATIONS,
+    CardAction,
+    CopyDefinition,
+)
+from .edit_state import EditState
+from .grouped_combo_box import GroupedComboBox
+
+base_description = """<p>Configure actions to perform on any destination note's card types.
+            Select a card type from the dropdown to configure its action.</p>"""
+
+source_to_destinations_description = (
+    "<p><small>Note: Card actions are performed on the queried notes' cards.</small></p>"
+)
+destination_to_sources_description = (
+    "<p><small>Note: Card actions are performed on the trigger note's cards.</small></p>"
+)
+
+
+class CardActionsEditor(QWidget):
+    """
+    Editor for card actions. Shows a dropdown to select card types from the selected note types,
+    and inline editors for each CardAction property (change_deck, set_flag, suspend, bury).
+    """
+
+    def __init__(
+        self,
+        parent,
+        state: EditState,
+        copy_definition: Optional[CopyDefinition],
+    ):
+        super().__init__(parent)
+        self.state = state
+        self.copy_definition = copy_definition
+        self.initialized = False
+
+        # Store callback entries for controlling visibility
+        self.selected_model_callback = state.add_selected_model_callback(
+            self.update_card_type_options, is_visible=False
+        )
+
+        self.vbox = QVBoxLayout()
+        self.setLayout(self.vbox)
+
+        # Add description label
+        self.description_label = QLabel()
+        self.vbox.addWidget(self.description_label)
+
+        # Container for all action editors (displayed inline)
+        self.actions_container_widget = QWidget()
+        self.actions_layout = QVBoxLayout(self.actions_container_widget)
+        self.actions_layout.setContentsMargins(0, 0, 0, 0)
+        self.vbox.addWidget(self.actions_container_widget)
+
+        # Add new action button and selector
+        self.add_action_form = QFormLayout()
+        self.card_type_selector = GroupedComboBox(is_required=False)
+        self.card_type_selector.setPlaceholderText("Select a card type to add")
+        self.add_action_button = QPushButton("Add Card Action")
+        self.add_action_button.clicked.connect(self.add_new_action)
+
+        add_action_layout = QHBoxLayout()
+        add_action_layout.addWidget(QLabel("<h3>Card Type:</h3>"))
+        add_action_layout.addWidget(self.card_type_selector)
+        add_action_layout.addWidget(self.add_action_button)
+        add_action_layout.addStretch()
+
+        self.vbox.addLayout(add_action_layout)
+
+        # Map card type names to their UI components
+        self.action_ui_components: Dict[str, Dict] = {}
+
+        # Map card type names to their CardAction definitions
+        self.card_actions: Dict[str, CardAction] = {}
+
+        # Load existing card actions from copy_definition
+        if copy_definition and copy_definition.get("card_actions"):
+            for action in copy_definition["card_actions"]:
+                card_type_name = action.get("card_type_name", "")
+                if card_type_name:
+                    self.card_actions[card_type_name] = action
+
+    def enable_callbacks(self):
+        """Enable callbacks when the widget becomes visible"""
+        self.selected_model_callback.is_visible = True
+
+    def disable_callbacks(self):
+        """Disable callbacks when the widget is not visible"""
+        self.selected_model_callback.is_visible = False
+
+    def set_description(self):
+        """Update the description label based on the current copy mode and direction"""
+        self.description_label.setText(
+            base_description
+            + (
+                source_to_destinations_description
+                if (
+                    self.state.copy_mode == COPY_MODE_ACROSS_NOTES
+                    and self.state.copy_direction == DIRECTION_SOURCE_TO_DESTINATIONS
+                )
+                else destination_to_sources_description
+            )
+        )
+
+    def initialize_ui_state(self):
+        """Perform expensive UI state initialization when component is first shown"""
+        if self.initialized:
+            return
+
+        self.enable_callbacks()
+        self.update_card_type_options()
+        self.set_description()
+
+        # Display all existing actions
+        for card_type_name, action in self.card_actions.items():
+            self.create_action_editor(card_type_name, action)
+
+        self.initialized = True
+
+    def update_card_type_options(self):
+        """
+        Depending on copy_mode, either update the card type dropdown with card types from
+        selected note types or all note types in the collection.
+        Only shows card types that haven't been added yet.
+        """
+        current_text = self.card_type_selector.currentText()
+        self.card_type_selector.blockSignals(True)
+        self.card_type_selector.clear()
+
+        has_available_types = False
+
+        if (
+            self.state.copy_mode == COPY_MODE_ACROSS_NOTES
+            and self.state.copy_direction == DIRECTION_SOURCE_TO_DESTINATIONS
+        ):
+            # in this mode, card actions apply to destination notes' cards so show all card types
+            # from all existing note types
+            all_note_types = mw.col.models.all()
+            for model in all_note_types:
+                model_name = model["name"]
+                templates = model.get("tmpls", [])
+
+                # Collect available templates for this model (not already added)
+                available_templates = []
+                for template in templates:
+                    template_name = template.get("name", "")
+                    item_text = f"{model_name}::{template_name}"
+                    # Only add if not already in card_actions
+                    if item_text not in self.card_actions:
+                        available_templates.append(item_text)
+
+                # Only add the group if there are available templates
+                if available_templates:
+                    self.card_type_selector.addGroup(model_name)
+                    for item_text in available_templates:
+                        self.card_type_selector.addItemToGroup(model_name, item_text)
+                        has_available_types = True
+
+            # Restore previous selection if it still exists and is still available
+            if current_text and current_text not in self.card_actions:
+                index = self.card_type_selector.findText(current_text)
+                if index >= 0:
+                    self.card_type_selector.setCurrentIndex(index)
+
+            self.card_type_selector.blockSignals(False)
+
+            # Disable if no available types
+            if not has_available_types:
+                self.card_type_selector.setPlaceholderText("All card types have been configured")
+                self.card_type_selector.setDisabled(True)
+                self.add_action_button.setDisabled(True)
+            else:
+                self.card_type_selector.setPlaceholderText("Select a card type to add")
+                self.card_type_selector.setDisabled(False)
+                self.add_action_button.setDisabled(False)
+
+            return
+
+        if not self.state.selected_models:
+            self.card_type_selector.setPlaceholderText("First, select a trigger note type")
+            self.card_type_selector.setDisabled(True)
+            self.add_action_button.setDisabled(True)
+            self.card_type_selector.blockSignals(False)
+            return
+
+        # Group card types by note type
+        for model in self.state.selected_models:
+            model_name = model["name"]
+            templates = model.get("tmpls", [])
+
+            # Collect available templates for this model (not already added)
+            available_templates = []
+            for template in templates:
+                template_name = template.get("name", "")
+                item_text = f"{model_name}::{template_name}"
+                # Only add if not already in card_actions
+                if item_text not in self.card_actions:
+                    available_templates.append(item_text)
+
+            # Only add the group if there are available templates
+            if available_templates:
+                self.card_type_selector.addGroup(model_name)
+                for item_text in available_templates:
+                    self.card_type_selector.addItemToGroup(model_name, item_text)
+                    has_available_types = True
+
+        # Restore previous selection if it still exists and is still available
+        if current_text and current_text not in self.card_actions:
+            index = self.card_type_selector.findText(current_text)
+            if index >= 0:
+                self.card_type_selector.setCurrentIndex(index)
+
+        self.card_type_selector.blockSignals(False)
+
+        # Disable if no available types
+        if not has_available_types:
+            self.card_type_selector.setPlaceholderText("All card types have been configured")
+            self.card_type_selector.setDisabled(True)
+            self.add_action_button.setDisabled(True)
+        else:
+            self.card_type_selector.setPlaceholderText("Select a card type to add")
+            self.card_type_selector.setDisabled(False)
+            self.add_action_button.setDisabled(False)
+
+    def add_new_action(self):
+        """Called when the Add Card Action button is clicked"""
+        card_type_name = self.card_type_selector.currentText()
+
+        if not card_type_name:
+            return
+
+        # Check if action already exists
+        if card_type_name in self.card_actions:
+            return
+
+        # Create new action
+        new_action: CardAction = {
+            "guid": str(uuid.uuid4()),
+            "card_type_name": card_type_name,
+            "change_deck": None,
+            "set_flag": None,
+            "suspend": None,
+            "bury": None,
+        }
+
+        self.card_actions[card_type_name] = new_action
+
+        # Create and display the action editor
+        self.create_action_editor(card_type_name, new_action)
+
+        # Clear the selector and refresh dropdown to remove the added card type
+        self.card_type_selector.setCurrentIndex(-1)
+        self.update_card_type_options()
+
+    def create_action_editor(self, card_type_name: str, action: CardAction):
+        """Create the UI for editing a single CardAction and add it inline"""
+        # Don't create if already exists
+        if card_type_name in self.action_ui_components:
+            return
+
+        # Create a frame for the action editor
+        frame = QFrame()
+        frame.setFrameShape(QFrameStyledPanel)
+        frame.setFrameShadow(QFrameShadowRaised)
+        frame_layout = QVBoxLayout(frame)
+
+        # Add frame to the actions layout
+        self.actions_layout.addWidget(frame)
+
+        # Header - show both model and card type in a readable format
+        # card_type_name is just the template name from GroupedComboBox
+        header = QLabel(f"<h3>Actions for card type: <em>{card_type_name}</em></h3>")
+        frame_layout.addWidget(header)
+
+        form_layout = QFormLayout()
+        frame_layout.addLayout(form_layout)
+
+        # 1. Change Deck dropdown
+        deck_combo = QComboBox()
+        deck_combo.addItem("-")  # Default: no action
+
+        # Add all decks
+        all_decks = mw.col.decks.all_names_and_ids()
+        for deck_name_and_id in all_decks:
+            deck_combo.addItem(deck_name_and_id.name)
+
+        # Set current value
+        current_deck = action.get("change_deck")
+        if current_deck:
+            index = deck_combo.findText(current_deck)
+            if index >= 0:
+                deck_combo.setCurrentIndex(index)
+        else:
+            deck_combo.setCurrentIndex(0)
+
+        form_layout.addRow(QLabel("<b>Move card to deck:</b>"), deck_combo)
+
+        # 2. Set Flag button group
+        flag_group = QButtonGroup()
+        flag_layout = QHBoxLayout()
+
+        flag_options = [
+            (None, "N/A"),
+            (0, "No flag"),
+            (1, "Red"),
+            (2, "Orange"),
+            (3, "Green"),
+            (4, "Blue"),
+            (5, "Pink"),
+            (6, "Turquoise"),
+            (7, "Purple"),
+        ]
+
+        current_flag = action.get("set_flag")
+        for value, text in flag_options:
+            radio = QRadioButton(text)
+            radio.setProperty("flag_value", value)
+            flag_group.addButton(radio)
+            flag_layout.addWidget(radio)
+
+            # Set checked state
+            if current_flag == value:
+                radio.setChecked(True)
+            elif current_flag is None and value is None:
+                radio.setChecked(True)
+
+        form_layout.addRow(QLabel("<b>Set card flag:</b>"), flag_layout)
+
+        # 3. Suspend button group
+        suspend_group = QButtonGroup()
+        suspend_layout = QHBoxLayout()
+
+        suspend_options = [
+            (None, "N/A"),
+            (True, "Suspend"),
+            (False, "Unsuspend"),
+        ]
+
+        current_suspend = action.get("suspend")
+        for value, text in suspend_options:
+            radio = QRadioButton(text)
+            radio.setProperty("suspend_value", value)
+            suspend_group.addButton(radio)
+            suspend_layout.addWidget(radio)
+
+            # Set checked state
+            if current_suspend == value:
+                radio.setChecked(True)
+            elif current_suspend is None and value is None:
+                radio.setChecked(True)
+
+        form_layout.addRow(QLabel("<b>Suspend card:</b>"), suspend_layout)
+
+        # 4. Bury button group
+        bury_group = QButtonGroup()
+        bury_layout = QHBoxLayout()
+
+        bury_options = [
+            (None, "N/A"),
+            (True, "Bury"),
+            (False, "Unbury"),
+        ]
+
+        current_bury = action.get("bury")
+        for value, text in bury_options:
+            radio = QRadioButton(text)
+            radio.setProperty("bury_value", value)
+            bury_group.addButton(radio)
+            bury_layout.addWidget(radio)
+
+            # Set checked state
+            if current_bury == value:
+                radio.setChecked(True)
+            elif current_bury is None and value is None:
+                radio.setChecked(True)
+
+        form_layout.addRow(QLabel("<b>Bury card:</b>"), bury_layout)
+
+        # Delete button
+        delete_button = QPushButton("Delete this card action")
+        delete_button.clicked.connect(lambda: self.delete_action(card_type_name))
+        form_layout.addRow("", delete_button)
+
+        # Store UI components for later retrieval
+        self.action_ui_components[card_type_name] = {
+            "frame": frame,
+            "deck_combo": deck_combo,
+            "flag_group": flag_group,
+            "suspend_group": suspend_group,
+            "bury_group": bury_group,
+        }
+
+    def save_action(self, card_type_name: str):
+        """Save a specific action from its UI components"""
+        if card_type_name not in self.action_ui_components:
+            return
+
+        ui_components = self.action_ui_components[card_type_name]
+        deck_combo = ui_components["deck_combo"]
+        flag_group = ui_components["flag_group"]
+        suspend_group = ui_components["suspend_group"]
+        bury_group = ui_components["bury_group"]
+
+        # Get change_deck value
+        deck_text = deck_combo.currentText()
+        change_deck = None if deck_text == "-" else deck_text
+
+        # Get set_flag value
+        set_flag = None
+        for button in flag_group.buttons():
+            if button.isChecked():
+                set_flag = button.property("flag_value")
+                break
+
+        # Get suspend value
+        suspend = None
+        for button in suspend_group.buttons():
+            if button.isChecked():
+                suspend = button.property("suspend_value")
+                break
+
+        # Get bury value
+        bury = None
+        for button in bury_group.buttons():
+            if button.isChecked():
+                bury = button.property("bury_value")
+                break
+
+        # Update the action
+        self.card_actions[card_type_name] = {
+            "guid": self.card_actions[card_type_name].get("guid", str(uuid.uuid4())),
+            "card_type_name": card_type_name,
+            "change_deck": change_deck,
+            "set_flag": set_flag,
+            "suspend": suspend,
+            "bury": bury,
+        }
+
+    def delete_action(self, card_type_name: str):
+        """Delete a card action and its UI"""
+        # Remove from data
+        if card_type_name in self.card_actions:
+            del self.card_actions[card_type_name]
+
+        # Remove from UI
+        if card_type_name in self.action_ui_components:
+            ui_components = self.action_ui_components[card_type_name]
+            frame = ui_components["frame"]
+            self.actions_layout.removeWidget(frame)
+            frame.deleteLater()
+            del self.action_ui_components[card_type_name]
+
+        # Refresh dropdown to show the deleted card type as available again
+        self.update_card_type_options()
+
+    def get_card_actions(self) -> list[CardAction]:
+        """Return the list of card actions"""
+        # Save all actions from their UI components
+        for card_type_name in list(self.action_ui_components.keys()):
+            self.save_action(card_type_name)
+
+        # Return only actions that have at least one non-None value
+        result = []
+        for action in self.card_actions.values():
+            if (
+                action.get("change_deck") is not None
+                or action.get("set_flag") is not None
+                or action.get("suspend") is not None
+                or action.get("bury") is not None
+            ):
+                result.append(action)
+
+        return result

--- a/ui/card_actions_editor.py
+++ b/ui/card_actions_editor.py
@@ -24,6 +24,7 @@ else:
     QFrameShadowRaised = QFrame.Raised  # type: ignore
 
 from ..configuration import (
+    CARD_TYPE_SEPARATOR,
     COPY_MODE_ACROSS_NOTES,
     DIRECTION_SOURCE_TO_DESTINATIONS,
     CardAction,
@@ -170,7 +171,7 @@ class CardActionsEditor(QWidget):
                 available_templates = []
                 for template in templates:
                     template_name = template.get("name", "")
-                    item_text = f"{model_name}::{template_name}"
+                    item_text = f"{model_name}{CARD_TYPE_SEPARATOR}{template_name}"
                     # Only add if not already in card_actions
                     if item_text not in self.card_actions:
                         available_templates.append(item_text)

--- a/ui/copy_field_to_field_editor.py
+++ b/ui/copy_field_to_field_editor.py
@@ -86,10 +86,8 @@ class CopyFieldToFieldEditor(QWidget):
         self.state = state
         if copy_definition is None:
             self.field_to_field_defs = []
-            field_to_file_defs = []
         else:
             self.field_to_field_defs = copy_definition.get("field_to_field_defs", [])
-            field_to_file_defs = copy_definition.get("field_to_file_defs", [])
         self.copy_definition = copy_definition
         self.copy_mode = copy_mode
 
@@ -128,11 +126,7 @@ class CopyFieldToFieldEditor(QWidget):
 
         self.copy_field_inputs: list[FieldInputsDict] = []
 
-        # Most copy definitions copy to note fields, so
-        # Initialize with one definition, if there are none, and there are no field-to-file defs
-        if len(self.field_to_field_defs) == 0 and len(field_to_file_defs) == 0:
-            self.add_new_definition()
-        elif len(self.field_to_field_defs) > 0:
+        if len(self.field_to_field_defs) > 0:
             for index, copy_field_to_field_definition in enumerate(self.field_to_field_defs):
                 self.add_copy_field_row(index, copy_field_to_field_definition)
 

--- a/ui/edit_copy_definition_dialog.py
+++ b/ui/edit_copy_definition_dialog.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from typing import Callable, Optional, Union, Tuple, cast
+import uuid
 
 
 from aqt import mw
@@ -1211,6 +1212,11 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
                 SelectCardByType, self.across_notes_editor_tab.card_select_cbox.currentText()
             )
             across_copy_definition: CopyDefinition = {
+                "guid": (
+                    self.copy_definition.get("guid", str(uuid.uuid4()))
+                    if self.copy_definition
+                    else str(uuid.uuid4())
+                ),
                 "definition_name": self.state.definition_name,
                 "copy_into_note_types": self.state.copy_into_note_types,
                 "only_copy_into_decks": self.state.only_copy_into_decks,
@@ -1250,6 +1256,11 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
             field_to_file_editor = self.within_note_editor_tab.get_field_to_file_editor()
             condition_query_editor = self.within_note_editor_tab.get_condition_query_editor()
             within_copy_definition: CopyDefinition = {
+                "guid": (
+                    self.copy_definition.get("guid", str(uuid.uuid4()))
+                    if self.copy_definition
+                    else str(uuid.uuid4())
+                ),
                 "definition_name": self.state.definition_name,
                 "copy_into_note_types": self.state.copy_into_note_types,
                 "only_copy_into_decks": self.state.only_copy_into_decks,

--- a/ui/edit_copy_definition_dialog.py
+++ b/ui/edit_copy_definition_dialog.py
@@ -134,10 +134,6 @@ class BasicEditorFormLayout(QFormLayout):
         self.note_type_target_cbox.addItems([f'"{model_name}"' for model_name in model_names_list])
         self.target_note_type_label = QLabel("<h3>Trigger (destination) note type</h3>")
         self.addRow(self.target_note_type_label, self.note_type_target_cbox)
-        state.connect_target_note_type_editor(
-            self.note_type_target_cbox,
-            self.set_note_type_warning,
-        )
 
         # Set up a label for showing a warning, if selecting multiple models
         self.note_type_target_warning = QLabel("")
@@ -160,6 +156,17 @@ class BasicEditorFormLayout(QFormLayout):
             self.decks_limit_multibox,
             self.update_deck_multibox_options,
         )
+
+        # Register callbacks that should be called when note types change
+        # This includes both the warning and deck options update
+        # The callback needs to be registered for model changes to update deck options
+        state.connect_target_note_type_editor(
+            self.note_type_target_cbox,
+            self.set_note_type_warning,
+        )
+
+        # Add a callback to update deck options when models change
+        state.add_selected_model_callback(self.update_deck_multibox_options, is_visible=True)
 
         self.include_subdecks_checkbox = QCheckBox("Include subdecks of selected decks")
         self.include_subdecks_checkbox.setChecked(False)

--- a/ui/edit_copy_definition_dialog.py
+++ b/ui/edit_copy_definition_dialog.py
@@ -33,6 +33,7 @@ from .copy_field_to_field_editor import CopyFieldToFieldEditor
 from .copy_field_to_file_editor import CopyFieldToFileEditor
 from .field_to_variable_editor import CopyFieldToVariableEditor
 from .tag_editor import TagEditor
+from .card_actions_editor import CardActionsEditor
 from .grouped_combo_box import GroupedComboBox
 from .interpolated_text_edit import InterpolatedTextEditLayout
 from .required_combobox import RequiredCombobox
@@ -599,6 +600,7 @@ class TabEditorComponents(QTabWidget):
         self.condition_widget = QWidget()
         self.card_query_widget = QWidget()
         self.tags_widget = QWidget()
+        self.card_actions_widget = QWidget()
         self.fields_widget = QWidget()
         self.files_widget = QWidget()
 
@@ -609,6 +611,7 @@ class TabEditorComponents(QTabWidget):
         if copy_mode == COPY_MODE_ACROSS_NOTES:
             self.addTab(self.card_query_widget, "Search Query")
         self.addTab(self.tags_widget, "Tags")
+        self.addTab(self.card_actions_widget, "Card Actions")
         self.addTab(self.fields_widget, "Field to Field")
         self.addTab(self.files_widget, "Field to File")
 
@@ -620,6 +623,7 @@ class TabEditorComponents(QTabWidget):
         self.across_query_tab_widget = None
         self.condition_query_tab_widget = None
         self.tag_editor = None
+        self.card_actions_editor = None
 
         # Connect tab change signal to lazy creation
         self.currentChanged.connect(self.on_tab_changed)
@@ -726,6 +730,28 @@ class TabEditorComponents(QTabWidget):
         self.tags_widget.adjustSize()
         self.created_tabs.add("tags")
 
+    def create_card_actions_tab(self):
+        if "card_actions" in self.created_tabs:
+            return
+        card_actions_layout = QVBoxLayout(self.card_actions_widget)
+        card_actions_layout.setAlignment(QAlignTop)
+
+        card_actions_layout.addWidget(QLabel("<h2>Card Actions</h2>"))
+
+        self.card_actions_editor = CardActionsEditor(self.parent, self.state, self.copy_definition)
+        card_actions_layout.addWidget(self.card_actions_editor)
+
+        spacer = QSpacerItem(100, 20, QSizePolicyExpanding, QSizePolicyMinimum)
+        card_actions_layout.addItem(spacer)
+        set_size_policy_for_all_widgets(card_actions_layout, QSizePolicyPreferred, QSizePolicyFixed)
+
+        # Initialize the editor's UI state
+        self.card_actions_editor.initialize_ui_state()
+
+        # Force the widget to update its size
+        self.card_actions_widget.adjustSize()
+        self.created_tabs.add("card_actions")
+
     def create_files_tab(self):
         if "files" in self.created_tabs:
             return
@@ -802,6 +828,8 @@ class TabEditorComponents(QTabWidget):
             self.create_fields_tab()
         elif tab_text == "Tags":
             self.create_tags_tab()
+        elif tab_text == "Card Actions":
+            self.create_card_actions_tab()
         elif tab_text == "Field to File":
             self.create_files_tab()
         elif tab_text == "Search Query":
@@ -847,6 +875,11 @@ class TabEditorComponents(QTabWidget):
         if "across_query" in self.created_tabs:
             return self.across_query_tab_widget
         return None
+
+    def get_card_actions_editor(self) -> CardActionsEditor:
+        if self.card_actions_editor is None:
+            self.create_card_actions_tab()
+        return self.card_actions_editor
 
 
 class AcrossNotesCopyEditor(QWidget):
@@ -941,6 +974,9 @@ class AcrossNotesCopyEditor(QWidget):
         """Get the query editor widget if it exists, otherwise None"""
         return self.editor_tabs.get_across_query_editor()
 
+    def get_card_actions_editor(self) -> CardActionsEditor:
+        return self.editor_tabs.get_card_actions_editor()
+
     def create_and_set_across_query_editor(self):
         if not self.query_editor:
             self.editor_tabs.create_across_query_tab()
@@ -1021,6 +1057,9 @@ class WithinNoteCopyEditor(QWidget):
 
     def get_condition_query_editor(self):
         return self.editor_tabs.get_condition_query_editor()
+
+    def get_card_actions_editor(self):
+        return self.editor_tabs.get_card_actions_editor()
 
     @property
     def condition_query_text_layout(self):
@@ -1207,6 +1246,7 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
             field_to_file_editor = self.across_notes_editor_tab.get_field_to_file_editor()
             field_to_variable_editor = self.across_notes_editor_tab.get_field_to_variable_editor()
             condition_query_editor = self.across_notes_editor_tab.get_condition_query_editor()
+            card_actions_editor = self.across_notes_editor_tab.get_card_actions_editor()
             # select_card_by has been validated in check_fields()
             select_card_by = cast(
                 SelectCardByType, self.across_notes_editor_tab.card_select_cbox.currentText()
@@ -1238,6 +1278,7 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
                 ),
                 "add_tags": tag_editor.get_add_tags(),
                 "remove_tags": tag_editor.get_remove_tags(),
+                "card_actions": card_actions_editor.get_card_actions(),
                 "sort_by_field": self.across_notes_editor_tab.sort_by_field_cbox.currentText(),
                 "select_card_by": select_card_by,
                 "select_card_count": self.across_notes_editor_tab.card_select_count.text(),
@@ -1255,6 +1296,7 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
             tag_editor = self.within_note_editor_tab.get_tag_editor()
             field_to_file_editor = self.within_note_editor_tab.get_field_to_file_editor()
             condition_query_editor = self.within_note_editor_tab.get_condition_query_editor()
+            card_actions_editor = self.within_note_editor_tab.get_card_actions_editor()
             within_copy_definition: CopyDefinition = {
                 "guid": (
                     self.copy_definition.get("guid", str(uuid.uuid4()))
@@ -1279,6 +1321,7 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
                 ),
                 "add_tags": tag_editor.get_add_tags(),
                 "remove_tags": tag_editor.get_remove_tags(),
+                "card_actions": card_actions_editor.get_card_actions(),
                 "copy_mode": COPY_MODE_WITHIN_NOTE,
                 "across_mode_direction": None,
                 "copy_from_cards_query": None,

--- a/ui/edit_state.py
+++ b/ui/edit_state.py
@@ -270,7 +270,7 @@ class EditState:
             for editor in checkbox_editors:
                 if editor is triggering_editor:
                     continue
-                editor.setChecked(self.copy_on_sync)
+                editor.setChecked(getattr(self, state_attr))
 
         def connect_func(
             checkbox: QCheckBox, callback: Optional[Callable[[QCheckBox], None]] = None

--- a/ui/edit_state.py
+++ b/ui/edit_state.py
@@ -104,6 +104,7 @@ class EditState:
             self.definition_name = copy_definition.get("definition_name", "")
             self.copy_into_note_types = copy_definition.get("copy_into_note_types", "")
             self.only_copy_into_decks = copy_definition.get("only_copy_into_decks", "")
+            self.include_subdecks = copy_definition.get("include_subdecks", False)
             self.copy_on_sync = copy_definition.get("copy_on_sync", False)
             self.copy_on_add = copy_definition.get("copy_on_add", False)
             self.copy_on_review = copy_definition.get("copy_on_review", False)

--- a/ui/pick_copy_definition_dialog.py
+++ b/ui/pick_copy_definition_dialog.py
@@ -446,14 +446,16 @@ class PickCopyDefinitionDialog(ScrollableQDialog):
 
     def duplicate_definition_by_guid(self, definition_guid: str):
         """Duplicate a specific definition by GUID."""
-        # Find the definition to duplicate
+        # Find the definition to duplicate and its index
         definition_to_duplicate = None
-        for definition in self.copy_definitions:
+        source_index = None
+        for i, definition in enumerate(self.copy_definitions):
             if definition.get("guid") == definition_guid:
                 definition_to_duplicate = definition
+                source_index = i
                 break
 
-        if definition_to_duplicate is None:
+        if definition_to_duplicate is None or source_index is None:
             return
 
         # Create a copy and assign new GUID
@@ -463,15 +465,16 @@ class PickCopyDefinitionDialog(ScrollableQDialog):
         copy_definition["definition_name"] += " (copy)"
         copy_definition["guid"] = str(uuid.uuid4())
 
-        config.add_definition(copy_definition)
-
-        # Add to local list and UI
-        self.copy_definitions.append(copy_definition)
-        self.add_definition_row(len(self.copy_definitions) - 1, copy_definition)
+        # Insert at the next index after the source
+        target_index = source_index + 1
+        config.insert_definition_at_index(target_index, copy_definition)
 
         # Reload config to stay in sync
         config.load()
         self.copy_definitions = config.copy_definitions
+
+        # Rebuild UI to reflect the new order
+        self.rebuild_definitions_ui()
 
     def reorder_definitions(self, source_guid: str, target_guid: str, drop_below: bool):
         """Reorder definitions by moving source before or after target"""

--- a/utils/merge_cards.py
+++ b/utils/merge_cards.py
@@ -4,7 +4,7 @@ from anki.cards import Card
 def merge_cards(card: Card, card_to_merge: Card) -> None:
     """Merge the editable details of card_to_merge into card. Mutates card.
 
-    Used to ensure that when peforming mw.col.update_card on a card,
+    Used to ensure that when performing mw.col.update_card on a card,
     all changes are included. This is because performing an update_card on a card
     with the same id will overwrite previous changes made to that card in the same
     operation.

--- a/utils/merge_cards.py
+++ b/utils/merge_cards.py
@@ -1,5 +1,3 @@
-import json
-
 from anki.cards import Card
 
 

--- a/utils/merge_cards.py
+++ b/utils/merge_cards.py
@@ -1,0 +1,32 @@
+import json
+
+from anki.cards import Card
+
+
+def merge_cards(card: Card, card_to_merge: Card) -> None:
+    """Merge the editable details of card_to_merge into card. Mutates card.
+
+    Used to ensure that when peforming mw.col.update_card on a card,
+    all changes are included. This is because performing an update_card on a card
+    with the same id will overwrite previous changes made to that card in the same
+    operation.
+
+    :param card: The card to merge into, will be mutated.
+    :param card_to_merge: The card to merge from.
+    """
+    # Sanity check, ids should match
+    if card.id != card_to_merge.id:
+        raise ValueError("Cannot merge cards with different IDs.")
+    # Merge custom data
+    card.custom_data = card_to_merge.custom_data
+
+    # Merge all other editable properties
+    card.due = card_to_merge.due
+    card.ivl = card_to_merge.ivl
+    card.factor = card_to_merge.factor
+    card.reps = card_to_merge.reps
+    card.queue = card_to_merge.queue
+    card.type = card_to_merge.type
+    card.odid = card_to_merge.odid
+    card.did = card_to_merge.did
+    card.flags = card_to_merge.flags

--- a/utils/move_card_to_deck.py
+++ b/utils/move_card_to_deck.py
@@ -34,4 +34,6 @@ def move_card_to_deck(
     else:
         card.did = deck_id
 
-    # undo action needs to be managed by the caller
+    # will not call mw.col.update_card(card) here.
+    # Instead the caller should do that in the most appropriate point to manage performance
+    # and undo entries.

--- a/utils/move_card_to_deck.py
+++ b/utils/move_card_to_deck.py
@@ -6,7 +6,7 @@ from .logger import Logger
 
 def move_card_to_deck(
     card: Card,
-    deck_name: str = "",
+    deck_name: str = None,
     deck_id: int = None,
     logger: Logger = None,
 ) -> None:

--- a/utils/move_card_to_deck.py
+++ b/utils/move_card_to_deck.py
@@ -1,0 +1,37 @@
+from aqt import mw
+from anki.cards import Card
+
+from .logger import Logger
+
+
+def move_card_to_deck(
+    card: Card,
+    deck_name: str = "",
+    deck_id: int = None,
+    logger: Logger = None,
+) -> None:
+    """Move the given card to the specified deck.
+
+    If deck_id is provided, it will be used directly. Otherwise,
+    the deck_name will be used to find the deck. A new deck cannot be created
+    by this function.
+    """
+    dm = mw.col.decks
+    if deck_id is None and deck_name is not None:
+        deck_id = dm.id_for_name(deck_name)
+        if not deck_id:
+            if logger:
+                logger.error(f"Deck '{deck_name}' not found. Cannot move card.")
+            return
+    elif deck_id is None:
+        if logger:
+            logger.error("Deck ID and name not provided. Cannot move card.")
+        return
+
+    # If odid is set, it means the card is in a filtered deck, we change the odid
+    if card.odid != 0:
+        card.odid = deck_id
+    else:
+        card.did = deck_id
+
+    # undo action needs to be managed by the caller


### PR DESCRIPTION
## Main feature

Implemented new backend and UI for card actions: move deck, flag, suspend & bury.
 - Card actions should be usable in both _Within note_ and _Across notes_ modes. In _Across notes_ mode with the direction being _Source to destinations_ the actions apply to cards for the queried notes.
 - To use different card actions per some conditions one will need multiple Copy definitions

## Other features

- Duplicating a Copy definition is placed into the next index instead of the end

## Misc bugfixes

- `include_subdecks` value wasn't initialized into the UI so was always unchecked
- Editing target notetype didn't update the deck limit combobox
