### PR TITLE
Copy as code and new card actions

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -194,7 +194,7 @@ class CardAction(TypedDict):
     set_flag: Optional[FlagValueType]
     suspend: Optional[bool]
     bury: Optional[bool]
-    set_desired_retention: Optional[Union[float, int]]
+    set_desired_retention: Optional[Union[float, int, str]]
 
 
 class CopyFieldToField(TypedDict):

--- a/configuration.py
+++ b/configuration.py
@@ -201,6 +201,8 @@ class CopyFieldToField(TypedDict):
     guid: str
     copy_into_note_field: str
     copy_from_text: str
+    copy_as_code: str
+    use_code: bool
     copy_if_empty: bool
     copy_on_unfocus_when_edit: bool
     copy_on_unfocus_when_add: bool
@@ -212,6 +214,8 @@ class CopyFieldToFile(TypedDict):
     guid: str
     copy_into_filename: str
     copy_from_text: str
+    copy_as_code: str
+    use_code: bool
     copy_if_empty: bool
     copy_on_unfocus_when_edit: bool
     copy_on_unfocus_when_add: bool
@@ -259,6 +263,8 @@ class CopyFieldToVariable(TypedDict):
     guid: str
     copy_into_variable: str
     copy_from_text: str
+    copy_as_code: str
+    use_code: bool
     process_chain: Sequence[AnyProcess]
 
 

--- a/configuration.py
+++ b/configuration.py
@@ -1,15 +1,15 @@
 import html
 import uuid
-from typing import TypedDict, Optional, Union, Literal, Sequence
-from typing_extensions import TypeGuard
+from typing import Literal, Optional, Sequence, TypedDict, Union
 
 from aqt import mw
+from typing_extensions import TypeGuard
 
-from .logic.jp_text_processing.kana.kana_highlight import FuriReconstruct
 from .logic.interpolate_fields import (
-    intr_format,
     TARGET_NOTES_COUNT,
+    intr_format,
 )
+from .logic.jp_text_processing.kana.kana_highlight import FuriReconstruct
 from .utils.logger import LogLevel
 
 tag = mw.addonManager.addonFromModule(__name__)
@@ -75,7 +75,9 @@ def get_fonts_check_process_label(fonts_check_process):
         fonts_limit = f", (limit {len(fonts_limit)} fonts)"
     else:
         fonts_limit = ""
-    return f"{FONTS_CHECK_PROCESS}: {fonts_check_process['fonts_dict_file']}{fonts_limit}"
+    return (
+        f"{FONTS_CHECK_PROCESS}: {fonts_check_process['fonts_dict_file']}{fonts_limit}"
+    )
 
 
 KANA_HIGHLIGHT_PROCESS = "Kana Highlight"
@@ -100,14 +102,20 @@ class WordHighlightProcess(TypedDict):
     word_field: str
 
 
-AnyProcess = Union[KanjiumToJavdejongProcess, RegexProcess, FontsCheckProcess, KanaHighlightProcess]
+AnyProcess = Union[
+    KanjiumToJavdejongProcess, RegexProcess, FontsCheckProcess, KanaHighlightProcess
+]
 
 
-def is_kana_highlight_process(process: Union[dict, AnyProcess]) -> TypeGuard[KanaHighlightProcess]:
+def is_kana_highlight_process(
+    process: Union[dict, AnyProcess],
+) -> TypeGuard[KanaHighlightProcess]:
     return process.get("name") == KANA_HIGHLIGHT_PROCESS
 
 
-def is_word_highlight_process(process: Union[dict, AnyProcess]) -> TypeGuard[WordHighlightProcess]:
+def is_word_highlight_process(
+    process: Union[dict, AnyProcess],
+) -> TypeGuard[WordHighlightProcess]:
     return process.get("name") == WORD_HIGHLIGHT_PROCESS
 
 
@@ -115,7 +123,9 @@ def is_regex_process(process: Union[dict, AnyProcess]) -> TypeGuard[RegexProcess
     return process.get("name") == REGEX_PROCESS
 
 
-def is_fonts_check_process(process: Union[dict, AnyProcess]) -> TypeGuard[FontsCheckProcess]:
+def is_fonts_check_process(
+    process: Union[dict, AnyProcess],
+) -> TypeGuard[FontsCheckProcess]:
     return process.get("name") == FONTS_CHECK_PROCESS
 
 
@@ -184,6 +194,7 @@ class CardAction(TypedDict):
     set_flag: Optional[FlagValueType]
     suspend: Optional[bool]
     bury: Optional[bool]
+    set_desired_retention: Optional[Union[float, int]]
 
 
 class CopyFieldToField(TypedDict):
@@ -214,23 +225,31 @@ def get_field_to_field_unfocus_trigger_fields(
     if modifies_other_notes:
         # source to destination mode is triggered by a field change in the trigger note
         # while the destination field is a different field in another note
-        return field_to_field.get("copy_on_unfocus_trigger_field", "").strip('""').split('", "')
+        return (
+            field_to_field.get("copy_on_unfocus_trigger_field", "")
+            .strip('""')
+            .split('", "')
+        )
     else:
         # destination to sources mode or within note mode the destination and trigger fields
         # are in the same note
-        return field_to_field.get("copy_on_unfocus_trigger_field", "").strip('""').split(
-            '", "'
-        ) or [field_to_field.get("copy_into_note_field", "")]
+        return field_to_field.get("copy_on_unfocus_trigger_field", "").strip(
+            '""'
+        ).split('", "') or [field_to_field.get("copy_into_note_field", "")]
 
 
 def get_triggered_field_to_field_def_for_field(
-    field_to_field_defs: list[CopyFieldToField], field_name: str, modifies_other_notes: bool
+    field_to_field_defs: list[CopyFieldToField],
+    field_name: str,
+    modifies_other_notes: bool,
 ) -> Union[CopyFieldToField, None]:
     """
     Get the field-to-field definition that matches the field_name and the mode.
     """
     for field_def in field_to_field_defs:
-        trigger_fields = get_field_to_field_unfocus_trigger_fields(field_def, modifies_other_notes)
+        trigger_fields = get_field_to_field_unfocus_trigger_fields(
+            field_def, modifies_other_notes
+        )
         if field_name in trigger_fields:
             return field_def
     return None
@@ -311,7 +330,6 @@ def migrate_config():
     config = Config()
     config.load()
     if compare_versions(config.version, "0.2.0") < 0:
-
         updated_definitions = []
         for definition in config.copy_definitions:
             if "guid" not in definition:
@@ -386,7 +404,8 @@ def definition_modifies_trigger_note(
 ) -> bool:
     targets_trigger_note = (
         copy_definition.get("copy_mode", None) == COPY_MODE_WITHIN_NOTE
-        or copy_definition.get("across_mode_direction", None) == DIRECTION_DESTINATION_TO_SOURCES
+        or copy_definition.get("across_mode_direction", None)
+        == DIRECTION_DESTINATION_TO_SOURCES
     )
     # definition might only save stuff to files
     has_field_to_field_defs = len(copy_definition.get("field_to_field_defs", [])) > 0
@@ -398,7 +417,8 @@ def definition_modifies_other_notes(
 ) -> bool:
     targets_other_notes = (
         copy_definition.get("copy_mode", None) == COPY_MODE_ACROSS_NOTES
-        or copy_definition.get("across_mode_direction", None) == DIRECTION_SOURCE_TO_DESTINATIONS
+        or copy_definition.get("across_mode_direction", None)
+        == DIRECTION_SOURCE_TO_DESTINATIONS
     )
     # definition might only save stuff to files
     has_field_to_field_defs = len(copy_definition.get("field_to_field_defs", [])) > 0

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1,71 +1,69 @@
 import base64
-import random
-import time
 import html
+import json
+import random
 import re
-from typing import Callable, Union, Optional, Tuple, Sequence, Any
+import time
+from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
-from anki.collection import OpChanges
 from anki.cards import Card
-from anki.notes import Note, NoteId
+from anki.collection import OpChanges
 from anki.decks import DeckId
+from anki.notes import Note, NoteId
 from anki.utils import ids2str
 from aqt import mw
 from aqt.operations import CollectionOp
-
 from aqt.qt import (
-    QWidget,
     QDialog,
-    QVBoxLayout,
-    QScrollArea,
     QGuiApplication,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
 )
 from aqt.utils import tooltip
 
-from ..utils.file_exists_in_media_folder import file_exists_in_media_folder
-from ..utils.write_to_media_folder import write_to_media_folder
-from ..utils.write_custom_data import write_custom_data
-from ..utils.logger import Logger
-from ..utils.move_card_to_deck import move_card_to_deck
-
-from .FatalProcessError import FatalProcessError
-from .fonts_check_process import fonts_check_process
-from .interpolate_fields import interpolate_from_text, TARGET_NOTES_COUNT
-from .kana_highlight_process import kana_highlight_process
-from .kana_highlight_process import WithTagsDef
-from .word_highlight_process import word_highlight_process
-from .kanjium_to_javdejong_process import kanjium_to_javdejong_process
-from .regex_process import regex_process
 from ..configuration import (
     CARD_TYPE_SEPARATOR,
+    COPY_MODE_ACROSS_NOTES,
+    COPY_MODE_WITHIN_NOTE,
+    DIRECTION_DESTINATION_TO_SOURCES,
+    DIRECTION_SOURCE_TO_DESTINATIONS,
+    SELECT_CARD_BY_VALUES,
+    CardAction,
     Config,
     CopyDefinition,
-    definition_modifies_other_notes,
-    CopyFieldToVariable,
     CopyFieldToField,
     CopyFieldToFile,
-    CardAction,
-    get_field_to_field_unfocus_trigger_fields,
-    COPY_MODE_WITHIN_NOTE,
-    COPY_MODE_ACROSS_NOTES,
-    DIRECTION_SOURCE_TO_DESTINATIONS,
-    DIRECTION_DESTINATION_TO_SOURCES,
-    SelectCardByType,
-    KanjiumToJavdejongProcess,
-    RegexProcess,
+    CopyFieldToVariable,
     FontsCheckProcess,
     KanaHighlightProcess,
-    is_kana_highlight_process,
-    is_word_highlight_process,
-    is_regex_process,
+    KanjiumToJavdejongProcess,
+    RegexProcess,
+    SelectCardByType,
+    definition_modifies_other_notes,
+    get_field_to_field_unfocus_trigger_fields,
     is_fonts_check_process,
+    is_kana_highlight_process,
     is_kanjium_to_javdejong_process,
-    SELECT_CARD_BY_VALUES,
+    is_regex_process,
+    is_word_highlight_process,
 )
 from ..ui.auto_resizing_text_edit import AutoResizingTextEdit
 from ..utils.duplicate_note import (
     duplicate_note,
 )
+from ..utils.file_exists_in_media_folder import file_exists_in_media_folder
+from ..utils.logger import Logger
+from ..utils.move_card_to_deck import move_card_to_deck
+from ..utils.write_custom_data import write_custom_data
+from ..utils.write_to_media_folder import write_to_media_folder
+from .FatalProcessError import FatalProcessError
+from .fonts_check_process import fonts_check_process
+from .interpolate_fields import TARGET_NOTES_COUNT, interpolate_from_text
+from .kana_highlight_process import WithTagsDef, kana_highlight_process
+from .kanjium_to_javdejong_process import kanjium_to_javdejong_process
+from .regex_process import regex_process
+from .word_highlight_process import word_highlight_process
 
 CONSOLE_COLOR_RE = r"\x1b\[[0-9;]*m"
 
@@ -176,7 +174,11 @@ class ProgressUpdateDef:
         self.max_value = max_value
 
     def has_update(self):
-        return self.label is not None or self.value is not None or self.max_value is not None
+        return (
+            self.label is not None
+            or self.value is not None
+            or self.max_value is not None
+        )
 
     def clear(self):
         self.label = None
@@ -249,22 +251,37 @@ class ProgressUpdater:
         elapsed_since_last_update = elapsed_s - self.last_render_update
         is_last_note = self.note_cnt == self.total_notes_count
         no_notes = not self.total_notes_count > 0
-        if (elapsed_since_last_update < 0.5 and not (force or is_last_note)) or no_notes:
+        if (
+            elapsed_since_last_update < 0.5 and not (force or is_last_note)
+        ) or no_notes:
             return
         self.last_render_update = elapsed_s
 
         elapsed_time = time.strftime("%H:%M:%S", time.gmtime(elapsed_s))
         label = f"""<strong>{html.escape(self.definition_name)}</strong>:
         <br>Copied {self.note_cnt}/{self.total_notes_count} notes
-        <br><small>Processed{f'-  destination notes: {self.total_processed_destinations}'
-                    if self.total_processed_destinations > 0 else ''}
-            {f'- files: {self.total_processed_files}' if self.total_processed_files > 0 else ''}
-            {f', sources: {self.total_processed_sources}' if self.is_across else ''}
-            {f', cards: {self.total_processed_cards}' if self.total_processed_cards > 0 else ''}
+        <br><small>Processed{
+            f"-  destination notes: {self.total_processed_destinations}"
+            if self.total_processed_destinations > 0
+            else ""
+        }
+            {
+            f"- files: {self.total_processed_files}"
+            if self.total_processed_files > 0
+            else ""
+        }
+            {f", sources: {self.total_processed_sources}" if self.is_across else ""}
+            {
+            f", cards: {self.total_processed_cards}"
+            if self.total_processed_cards > 0
+            else ""
+        }
         </small><br>Time: {elapsed_time}"""
         if self.note_cnt / self.total_notes_count > 0.10 or elapsed_s > 1:
             if self.note_cnt > 0:
-                eta_s = (elapsed_s / self.note_cnt) * (self.total_notes_count - self.note_cnt)
+                eta_s = (elapsed_s / self.note_cnt) * (
+                    self.total_notes_count - self.note_cnt
+                )
                 eta = time.strftime("%H:%M:%S", time.gmtime(eta_s))
                 label += f" - ETA: {eta}"
         value = self.note_cnt
@@ -371,7 +388,9 @@ def copy_fields(
                     y_offset=100,
                 )
         if not is_sync and len(debug_texts) > 0:
-            ScrollMessageBox(debug_texts, title="Copy fields debug Messages", parent=parent)
+            ScrollMessageBox(
+                debug_texts, title="Copy fields debug Messages", parent=parent
+            )
         if on_done is not None:
             on_done()
 
@@ -379,7 +398,9 @@ def copy_fields(
         mw.progress.finish()
         logger.error(f"Copying failed: {exception}")
         if not is_sync and len(debug_texts) > 0:
-            ScrollMessageBox(debug_texts, title="Copy Fields debug Messages", parent=parent)
+            ScrollMessageBox(
+                debug_texts, title="Copy Fields debug Messages", parent=parent
+            )
         if on_done is not None:
             on_done()
         # Need to raise the exception to get the traceback to the cause in the console
@@ -417,7 +438,9 @@ def copy_fields(
             results = copy_fields_in_background(
                 copy_definition=copy_definition,
                 note_ids=(
-                    note_ids_per_definition[i] if note_ids_per_definition is not None else note_ids
+                    note_ids_per_definition[i]
+                    if note_ids_per_definition is not None
+                    else note_ids
                 ),
                 logger=logger,
                 is_sync=is_sync,
@@ -458,7 +481,8 @@ def copy_fields(
             # Ensure that all fc flags are reset in the DB, if the notes/cards were not
             # modified during the copy operations
             rest_cards = [
-                mw.col.get_card(cid) for cid in mw.col.find_cards("prop:cdn:fc=-1 OR prop:cdn:fc=0")
+                mw.col.get_card(cid)
+                for cid in mw.col.find_cards("prop:cdn:fc=-1 OR prop:cdn:fc=0")
             ]
             for card in rest_cards:
                 write_custom_data(card, key="fc", value=1)
@@ -542,9 +566,9 @@ def copy_fields_in_background(
         FROM notes n, cards c
         WHERE n.mid IN {ids2str(note_type_ids)}
         AND c.nid = n.id
-        AND json_extract(json_extract(c.data, '$.cd'), '$.fc') {f"IN (0, -1)"
-                                                                if copy_on_sync_after_review
-                                                                else "= 0"}
+        AND json_extract(json_extract(c.data, '$.cd'), '$.fc') {
+                f"IN (0, -1)" if copy_on_sync_after_review else "= 0"
+            }
         {nids_query}
         """
             if is_sync
@@ -621,10 +645,10 @@ def copy_fields_in_background(
         #  Get counts from ProgressUpdater and render the final update
         results.add_result_text(f"""<br><span>
             {time.time() - start_time:.2f}s -
-            <i>{html.escape(copy_definition['definition_name'])}:</i>
-            {f'{total_processed_dests} destinations' if total_processed_dests > 0 else ''}
-            {f'{total_processed_files} files' if total_processed_files > 0 else ''}
-            {f'{total_processed_cards} cards' if total_processed_cards > 0 else ''}
+            <i>{html.escape(copy_definition["definition_name"])}:</i>
+            {f"{total_processed_dests} destinations" if total_processed_dests > 0 else ""}
+            {f"{total_processed_files} files" if total_processed_files > 0 else ""}
+            {f"{total_processed_cards} cards" if total_processed_cards > 0 else ""}
             {f'''processed with {total_processed_sources} sources''' if is_across else "processed"}
         </span>""")
         results.incr_count(1)
@@ -790,7 +814,9 @@ def copy_for_single_trigger_note(
     copy_from_cards_query = copy_definition.get("copy_from_cards_query", None)
     copy_condition_query = copy_definition.get("copy_condition_query", None)
     condition_only_on_sync = copy_definition.get("condition_only_on_sync", False)
-    run_also_if_no_sources_found = copy_definition.get("run_also_if_no_sources_found", False)
+    run_also_if_no_sources_found = copy_definition.get(
+        "run_also_if_no_sources_found", False
+    )
     add_tags = copy_definition.get("add_tags", "")
     remove_tags = copy_definition.get("remove_tags", "")
     sort_by_field = copy_definition.get("sort_by_field", None)
@@ -824,7 +850,8 @@ def copy_for_single_trigger_note(
         target_deck_names = only_copy_into_decks.strip('""').split('", "')
 
         unique_whitelist_dids: set[DeckId] = {
-            mw.col.decks.id_for_name(target_deck_name) for target_deck_name in target_deck_names
+            mw.col.decks.id_for_name(target_deck_name)
+            for target_deck_name in target_deck_names
         }
         if include_subdecks:
             parent_dids = set()
@@ -864,7 +891,9 @@ def copy_for_single_trigger_note(
         )
         if interpolated_condition_query:
             # Search for notes, this works for card properties just as well
-            note_ids = mw.col.find_notes(f"{interpolated_condition_query} nid:{trigger_note.id}")
+            note_ids = mw.col.find_notes(
+                f"{interpolated_condition_query} nid:{trigger_note.id}"
+            )
             if (note_ids is None) or (len(note_ids) == 0):
                 logger.debug(
                     "copy_for_single_trigger_note: "
@@ -929,7 +958,9 @@ def copy_for_single_trigger_note(
 
     if len(source_notes) == 0 and not run_also_if_no_sources_found:
         if progress_updater is not None:
-            progress_updater.update_counts(processed_destinations_inc=len(destination_notes))
+            progress_updater.update_counts(
+                processed_destinations_inc=len(destination_notes)
+            )
         # This case is ok, there's just nothing to do
         # But we need to end early here so that the target fields aren't wiped
         # So, return True
@@ -940,22 +971,26 @@ def copy_for_single_trigger_note(
     # Step 3: Get value for each field we are copying into
     for destination_note in destination_notes:
         try:
-            copied_into_dest_note, copied_into_file, dest_note_cards = copy_into_single_note(
-                field_to_field_defs=field_to_field_defs,
-                field_to_file_defs=field_to_file_defs,
-                card_actions=card_actions,
-                destination_note=destination_note,
-                source_notes=source_notes,
-                add_tags=add_tags,
-                remove_tags=remove_tags,
-                variable_values_dict=variable_values_dict,
-                field_only=field_only,
-                modifies_other_notes=definition_modifies_other_notes(copy_definition),
-                multiple_note_types=multiple_note_types,
-                select_card_separator=select_card_separator,
-                file_cache=file_cache,
-                logger=logger,
-                progress_updater=progress_updater,
+            copied_into_dest_note, copied_into_file, dest_note_cards = (
+                copy_into_single_note(
+                    field_to_field_defs=field_to_field_defs,
+                    field_to_file_defs=field_to_file_defs,
+                    card_actions=card_actions,
+                    destination_note=destination_note,
+                    source_notes=source_notes,
+                    add_tags=add_tags,
+                    remove_tags=remove_tags,
+                    variable_values_dict=variable_values_dict,
+                    field_only=field_only,
+                    modifies_other_notes=definition_modifies_other_notes(
+                        copy_definition
+                    ),
+                    multiple_note_types=multiple_note_types,
+                    select_card_separator=select_card_separator,
+                    file_cache=file_cache,
+                    logger=logger,
+                    progress_updater=progress_updater,
+                )
             )
             if progress_updater is not None:
                 progress_updater.update_counts(
@@ -1016,7 +1051,9 @@ def copy_into_single_note(
         try:
             cur_field_value = destination_note[copy_into_note_field]
         except KeyError:
-            logger.error(f"Error in copy fields: Field '{copy_into_note_field}' not found in note")
+            logger.error(
+                f"Error in copy fields: Field '{copy_into_note_field}' not found in note"
+            )
             # Rest of defs are not processed
             raise CopyFailedException
 
@@ -1143,7 +1180,9 @@ def copy_into_single_note(
             )
             # Skip this card action
             continue
-        note_type_name, card_type_name = note_type_and_card_type.split(CARD_TYPE_SEPARATOR, 1)
+        note_type_name, card_type_name = note_type_and_card_type.split(
+            CARD_TYPE_SEPARATOR, 1
+        )
         if note_type_name != dest_note_type["name"]:
             # This card action is not for this note type
             continue
@@ -1159,6 +1198,7 @@ def copy_into_single_note(
         suspend_card = card_action.get("suspend", None)
         bury_card = card_action.get("bury", None)
         set_flag = card_action.get("set_flag", None)
+        set_dr = card_action.get("set_desired_retention", None)
         if change_deck not in [None, "-"]:
             move_card_to_deck(card, change_deck, logger=logger)
             card.edited = True
@@ -1180,6 +1220,16 @@ def copy_into_single_note(
         if isinstance(set_flag, int) and 0 <= set_flag <= 7:
             card.set_user_flag(set_flag)
             card.edited = True
+        if set_dr is not None:
+            if isinstance(set_dr, str):
+                # Get value from custom data property
+                set_dr = json.loads(card.custom_data).get(set_dr, None)
+            if isinstance(set_dr, int):
+                set_dr = float(set_dr) / 100
+            if isinstance(set_dr, float) and 0 < set_dr < 1:
+                card.desired_retention = set_dr
+                card.edited = True
+
         if progress_updater is not None and hasattr(card, "edited") and card.edited:
             progress_updater.update_counts(processed_cards_inc=1)
     return (modified_dest_note, wrote_to_file, dest_note_cards)
@@ -1289,7 +1339,9 @@ def get_across_target_notes(
     )
 
     if not select_card_by:
-        logger.error("Error in copy fields: Required value 'select_card_by' was missing.")
+        logger.error(
+            "Error in copy fields: Required value 'select_card_by' was missing."
+        )
         return []
 
     if select_card_by not in SELECT_CARD_BY_VALUES:
@@ -1323,9 +1375,13 @@ def get_across_target_notes(
         f" invalid_fields={invalid_fields}"
     )
     if not interpolated_cards_query:
-        logger.error("Error in copy fields: Could not interpolate copy_from_cards_query")
+        logger.error(
+            "Error in copy fields: Could not interpolate copy_from_cards_query"
+        )
         return []
-    cards_query_id = base64.b64encode(f"cards{interpolated_cards_query}".encode()).decode()
+    cards_query_id = base64.b64encode(
+        f"cards{interpolated_cards_query}".encode()
+    ).decode()
     try:
         card_ids = extra_state[cards_query_id]
     except KeyError:
@@ -1345,14 +1401,18 @@ def get_across_target_notes(
                 f" copy_from_cards_query='{interpolated_cards_query}'"
             )
         else:
-            logger.debug(f'No cards found with copy_from_cards_query="{interpolated_cards_query}",')
+            logger.debug(
+                f'No cards found with copy_from_cards_query="{interpolated_cards_query}",'
+            )
         return []
 
     has_sort_by_field = sort_by_field and sort_by_field != "-"
 
     def sort_notes(notes: list[Note]):
         if has_sort_by_field:
-            notes.sort(key=lambda n: int_sort_by_field_value(n, sort_by_field), reverse=True)
+            notes.sort(
+                key=lambda n: int_sort_by_field_value(n, sort_by_field), reverse=True
+            )
         return notes
 
     assert mw.col.db is not None
@@ -1372,7 +1432,9 @@ def get_across_target_notes(
         if select_card_by == "None" and len(card_ids) > 0:
             selected_card_id = card_ids.pop()
             if selected_card_id:
-                selected_notes.append(mw.col.get_note(mw.col.get_card(selected_card_id).nid))
+                selected_notes.append(
+                    mw.col.get_note(mw.col.get_card(selected_card_id).nid)
+                )
             continue
         elif len(card_ids) == 0:
             break
@@ -1395,7 +1457,9 @@ def get_across_target_notes(
             except KeyError:
                 selected_card_id = min(
                     card_ids,
-                    key=lambda c: db.scalar(f"SELECT COUNT() FROM revlog WHERE cid = {c}"),
+                    key=lambda c: db.scalar(
+                        f"SELECT COUNT() FROM revlog WHERE cid = {c}"
+                    ),
                 )
                 extra_state = {card_select_key: selected_card_id}
         if selected_card_id is None:

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -57,6 +57,7 @@ from ..utils.logger import Logger
 from ..utils.move_card_to_deck import move_card_to_deck
 from ..utils.write_custom_data import write_custom_data
 from ..utils.write_to_media_folder import write_to_media_folder
+from .execute_code import execute_code
 from .FatalProcessError import FatalProcessError
 from .fonts_check_process import fonts_check_process
 from .interpolate_fields import TARGET_NOTES_COUNT, interpolate_from_text
@@ -1003,7 +1004,9 @@ def copy_for_single_trigger_note(
                 # Add cards to the dict so they can be updated later
                 for new_card in dest_note_cards:
                     copied_into_cards_dict[new_card.id] = new_card
-        except CopyFailedException:
+        except CopyFailedException as e:
+            if str(e):
+                logger.error(str(e))
             return False
 
     return True
@@ -1045,6 +1048,8 @@ def copy_into_single_note(
             # Note, depending on the mode, may be that field_only == copy_into_note_field
             continue
         copy_from_text = field_to_field_def.get("copy_from_text", "")
+        copy_as_code = field_to_field_def.get("copy_as_code", "")
+        use_code = field_to_field_def.get("use_code", False)
         copy_if_empty = field_to_field_def.get("copy_if_empty", False)
         process_chain = field_to_field_def.get("process_chain", None)
 
@@ -1061,11 +1066,12 @@ def copy_into_single_note(
             continue
 
         result_val = get_field_values_from_notes(
-            copy_from_text=copy_from_text,
+            copy_from_text=copy_as_code if use_code else copy_from_text,
             notes=source_notes,
             dest_note=destination_note_copy,
             multiple_note_types=multiple_note_types,
             select_card_separator=select_card_separator,
+            use_code=use_code,
             logger=logger,
             variable_values_dict=variable_values_dict,
             progress_updater=progress_updater,
@@ -1109,6 +1115,8 @@ def copy_into_single_note(
     for field_to_file_def in field_to_file_defs:
         copy_into_filename = field_to_file_def.get("copy_into_filename", "")
         copy_from_text = field_to_file_def.get("copy_from_text", "")
+        copy_as_code = field_to_file_def.get("copy_as_code", "")
+        use_code = field_to_file_def.get("use_code", False)
         process_chain = field_to_file_def.get("process_chain", None)
         dont_overwrite = field_to_file_def.get("copy_if_empty", False)
 
@@ -1116,7 +1124,7 @@ def copy_into_single_note(
             logger.error("Error in copy fields: No file name provided")
             raise CopyFailedException
 
-        # Interpolate filename with values from the note
+        # Interpolate filename with values from the note (never executed as code)
         copy_into_filename = get_field_values_from_notes(
             copy_from_text=copy_into_filename,
             notes=[destination_note],
@@ -1132,11 +1140,12 @@ def copy_into_single_note(
             continue
 
         result_val = get_field_values_from_notes(
-            copy_from_text=copy_from_text,
+            copy_from_text=copy_as_code if use_code else copy_from_text,
             notes=source_notes,
             dest_note=destination_note_copy,
             multiple_note_types=multiple_note_types,
             select_card_separator=select_card_separator,
+            use_code=use_code,
             logger=logger,
             variable_values_dict=variable_values_dict,
             progress_updater=progress_updater,
@@ -1254,11 +1263,14 @@ def get_variable_values_for_note(
     for field_to_variable_def in field_to_variable_defs:
         copy_into_variable = field_to_variable_def["copy_into_variable"]
         copy_from_text = field_to_variable_def["copy_from_text"]
+        copy_as_code = field_to_variable_def.get("copy_as_code", "")
+        use_code = field_to_variable_def.get("use_code", False)
+        active_text = copy_as_code if use_code else copy_from_text
         process_chain = field_to_variable_def.get("process_chain", None)
 
         # Step 1: Interpolate the text with values from the note
         interpolated_value, invalid_fields = interpolate_from_text(
-            copy_from_text,
+            active_text,
             source_note=note,
         )
         if len(invalid_fields) > 0:
@@ -1266,6 +1278,14 @@ def get_variable_values_for_note(
                 "Error getting variable values: Invalid fields in copy_from_text:"
                 f" {', '.join(invalid_fields)}"
             )
+
+        # Step 1b: Execute as code if requested
+        if use_code and interpolated_value is not None:
+            interpolated_value, code_error = execute_code(interpolated_value, note)
+            if code_error:
+                raise CopyFailedException(
+                    f"Code execution error in variable '{copy_into_variable}':\n{code_error}"
+                )
 
         # Step 2: If we have further processing steps, run them
         if process_chain is not None and interpolated_value is not None:
@@ -1487,6 +1507,7 @@ def get_field_values_from_notes(
     multiple_note_types: bool = False,
     variable_values_dict: Optional[dict] = None,
     select_card_separator: Optional[str] = ", ",
+    use_code: bool = False,
     logger: Logger = Logger("error"),
     progress_updater: Optional[ProgressUpdater] = None,
 ) -> str:
@@ -1502,6 +1523,8 @@ def get_field_values_from_notes(
     :param variable_values_dict: A dictionary of custom variable values to use in interpolating text
     :param select_card_separator: The separator to use when joining the values from the notes.
         Irrelevant if there is only one note
+    :param use_code: When True, the interpolated text is executed as Python code and the return
+        value of that code is used as the result instead of the interpolated text itself.
     :param logger: Logger to use for errors and debug messages, used for storing all messages
         until the end of the whole operation to show them in a GUI element at the end
     :param progress_updater: An object to update the progress bar with
@@ -1539,8 +1562,16 @@ def get_field_values_from_notes(
                 f" {', '.join(invalid_fields)}"
             )
 
+        if use_code:
+            interpolated_value, code_error = execute_code(interpolated_value, note)
+            if code_error:
+                raise CopyFailedException(f"Code execution error:\n{code_error}")
+
         if progress_updater is not None:
             progress_updater.maybe_render_update()
-        result_val += f"{select_card_separator if i > 0 else ''}{interpolated_value}"
+        if interpolated_value is not None:
+            result_val += (
+                f"{select_card_separator if i > 0 else ''}{interpolated_value}"
+            )
 
     return result_val

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1232,7 +1232,14 @@ def copy_into_single_note(
         if set_dr is not None:
             if isinstance(set_dr, str):
                 # Get value from custom data property
-                set_dr = json.loads(card.custom_data).get(set_dr, None)
+                if card.custom_data:
+                    try:
+                        custom_data = json.loads(card.custom_data)
+                    except json.JSONDecodeError:
+                        custom_data = {}
+                    set_dr = custom_data.get(set_dr, None)
+                else:
+                    set_dr = None
             if isinstance(set_dr, int) and not isinstance(set_dr, bool):
                 set_dr = float(set_dr) / 100
             if isinstance(set_dr, float) and 0 < set_dr < 1:

--- a/logic/copy_fields.py
+++ b/logic/copy_fields.py
@@ -1233,7 +1233,7 @@ def copy_into_single_note(
             if isinstance(set_dr, str):
                 # Get value from custom data property
                 set_dr = json.loads(card.custom_data).get(set_dr, None)
-            if isinstance(set_dr, int):
+            if isinstance(set_dr, int) and not isinstance(set_dr, bool):
                 set_dr = float(set_dr) / 100
             if isinstance(set_dr, float) and 0 < set_dr < 1:
                 card.desired_retention = set_dr

--- a/logic/execute_code.py
+++ b/logic/execute_code.py
@@ -141,8 +141,8 @@ def execute_code(code: str, note: Note) -> Tuple[Union[str, None], Optional[str]
         ``return``).  ``{{field}}`` markers have already been interpolated.
     :param note: The current source note, available as ``note`` inside the
         code.
-    :return: ``(result_string, error_message)`` — *error_message* is ``None``
-        on success.
+    :return: ``(result_string|None, error_message)`` — *error_message* is ``None``
+        on success. None indicates error or invalid return value.
     """
     if not code.strip():
         return "", None
@@ -176,7 +176,7 @@ def execute_code(code: str, note: Note) -> Tuple[Union[str, None], Optional[str]
         if e.text:
             col = max(0, (e.offset or 1) - 1)
             pointer = f"\n    {e.text.rstrip()}\n    {' ' * col}^"
-        return "", f"{kind} (line {user_lineno}): {e.msg}{pointer}"
+        return None, f"{kind} (line {user_lineno}): {e.msg}{pointer}"
 
     try:
         exec(compiled, exec_globals)  # noqa: S102

--- a/logic/execute_code.py
+++ b/logic/execute_code.py
@@ -15,7 +15,7 @@ against *accidental* misuse, not a cryptographic boundary.
 What IS restricted: ``__import__``, ``open``, ``exec``, ``eval``,
 ``compile``, ``breakpoint``, ``os``, ``sys``, network access.
 What IS allowed: the explicit allowlist below (``re``, ``json``, ``html``,
-``find_cards``, ``find_notes``, ``note``) plus a curated set of built-ins.
+``print``, ``find_cards``, ``find_notes``, ``note``) plus a curated set of built-ins.
 """
 
 import html
@@ -31,7 +31,7 @@ from aqt import mw
 # ---------------------------------------------------------------------------
 # Safe built-ins whitelist
 # Notably absent: __import__, open, exec, eval, compile, breakpoint,
-#                 globals, locals, vars, __build_class__, input, print, setattr
+#                 globals, locals, vars, __build_class__, input, setattr
 # ---------------------------------------------------------------------------
 _SAFE_BUILTINS: dict = {
     # Type constructors

--- a/logic/execute_code.py
+++ b/logic/execute_code.py
@@ -1,0 +1,207 @@
+"""Executes user-provided Python code in a restricted namespace.
+
+The code is expected to be the body of a function (using ``return`` to produce
+the result).  ``{{field}}`` interpolation markers are resolved *before* this
+module is invoked, so the code text already contains the final field values.
+
+Security notes
+--------------
+Python does not provide a true sandbox.  A sufficiently motivated user can
+escape the restricted ``__builtins__`` via introspection (e.g. accessing
+``''.__class__.__mro__[1].__subclasses__()``).  Because this addon runs
+locally and the user writes their own code, the restriction is a safeguard
+against *accidental* misuse, not a cryptographic boundary.
+
+What IS restricted: ``__import__``, ``open``, ``exec``, ``eval``,
+``compile``, ``breakpoint``, ``os``, ``sys``, network access.
+What IS allowed: the explicit allowlist below (``re``, ``json``, ``html``,
+``find_cards``, ``find_notes``, ``note``) plus a curated set of built-ins.
+"""
+
+import html
+import json
+import re
+import textwrap
+import traceback
+from typing import Optional, Tuple, Union
+
+from anki.notes import Note
+from aqt import mw
+
+# ---------------------------------------------------------------------------
+# Safe built-ins whitelist
+# Notably absent: __import__, open, exec, eval, compile, breakpoint,
+#                 globals, locals, vars, __build_class__, input, print, setattr
+# ---------------------------------------------------------------------------
+_SAFE_BUILTINS: dict = {
+    # Type constructors
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+    "set": set,
+    "frozenset": frozenset,
+    "tuple": tuple,
+    "bytes": bytes,
+    "bytearray": bytearray,
+    # Singletons
+    "None": None,
+    "True": True,
+    "False": False,
+    # Numeric
+    "abs": abs,
+    "round": round,
+    "min": min,
+    "max": max,
+    "sum": sum,
+    "pow": pow,
+    "divmod": divmod,
+    # Sequence / iteration
+    "len": len,
+    "range": range,
+    "sorted": sorted,
+    "reversed": reversed,
+    "enumerate": enumerate,
+    "zip": zip,
+    "map": map,
+    "filter": filter,
+    "any": any,
+    "all": all,
+    "next": next,
+    "iter": iter,
+    # Type inspection (read-intent only)
+    "isinstance": isinstance,
+    "issubclass": issubclass,
+    "type": type,
+    "callable": callable,
+    "hasattr": hasattr,
+    "getattr": getattr,
+    # Repr / formatting
+    "repr": repr,
+    "format": format,
+    "chr": chr,
+    "ord": ord,
+    "hex": hex,
+    "oct": oct,
+    "bin": bin,
+    "hash": hash,
+    # Exceptions
+    "Exception": Exception,
+    "ValueError": ValueError,
+    "TypeError": TypeError,
+    "KeyError": KeyError,
+    "IndexError": IndexError,
+    "AttributeError": AttributeError,
+    "StopIteration": StopIteration,
+    "RuntimeError": RuntimeError,
+    "NotImplementedError": NotImplementedError,
+    # JSON errors
+    "JSONDecodeError": json.JSONDecodeError,
+}
+
+
+class _ReadOnlyNote:
+    """Thin read-only proxy around an Anki Note.
+
+    Exposes only ``note[field_name]`` (``__getitem__``) and ``note.keys()`` so
+    that user code can read field values but cannot modify them.  This prevents
+    accidental (or intentional) mutation of the source note during code
+    execution, which would otherwise corrupt the note object shared with the
+    rest of the copy pipeline.
+    """
+
+    __slots__ = ("_note",)
+
+    def __init__(self, note: Note) -> None:
+        object.__setattr__(self, "_note", note)
+
+    def __getitem__(self, key: str) -> str:
+        return object.__getattribute__(self, "_note")[key]
+
+    def keys(self):
+        return object.__getattribute__(self, "_note").keys()
+
+    def __setitem__(self, key: str, value: str) -> None:
+        raise TypeError("note fields are read-only inside code execution")
+
+    def __setattr__(self, name: str, value) -> None:
+        raise TypeError("note fields are read-only inside code execution")
+
+
+def execute_code(code: str, note: Note) -> Tuple[Union[str, None], Optional[str]]:
+    """Execute user-provided Python code in a restricted namespace.
+
+    The code is wrapped in a function body so that ``return`` statements work
+    naturally.  The return value is coerced to ``str``; ``None`` (no
+    ``return``) becomes ``""``.
+
+    :param code: The Python code to run (function body, may include
+        ``return``).  ``{{field}}`` markers have already been interpolated.
+    :param note: The current source note, available as ``note`` inside the
+        code.
+    :return: ``(result_string, error_message)`` — *error_message* is ``None``
+        on success.
+    """
+    if not code.strip():
+        return "", None
+
+    indented = textwrap.indent(code, "    ")
+    wrapped = f"def _user_func():\n{indented}\n_result = _user_func()\n"
+
+    # Copy _SAFE_BUILTINS per-call so that exec cannot leak mutations between
+    # invocations (Python exposes __builtins__ inside exec'd namespaces and
+    # user code could mutate the dict if it were shared).
+    exec_globals: dict = {
+        "__builtins__": dict(_SAFE_BUILTINS),
+        "re": re,
+        "json": json,
+        "html": html,
+        "print": print,
+        "find_cards": mw.col.find_cards,
+        "find_notes": mw.col.find_notes,
+        "note": _ReadOnlyNote(note),
+    }
+
+    try:
+        compiled = compile(wrapped, "<copy_anywhere_code>", "exec")
+    except SyntaxError as e:
+        user_lineno = max(1, (e.lineno or 1) - 1)  # subtract the injected def line
+        kind = (
+            "Indentation error" if isinstance(e, IndentationError) else "Syntax error"
+        )
+        # e.text is the offending source line; e.offset is the column (1-based)
+        pointer = ""
+        if e.text:
+            col = max(0, (e.offset or 1) - 1)
+            pointer = f"\n    {e.text.rstrip()}\n    {' ' * col}^"
+        return "", f"{kind} (line {user_lineno}): {e.msg}{pointer}"
+
+    try:
+        exec(compiled, exec_globals)  # noqa: S102
+    except Exception:  # noqa: BLE001
+        # Extract the traceback, strip frames that belong to execute_code itself,
+        # and shift line numbers back by 1 to account for the injected `def` line.
+        tb_lines = traceback.format_exc().splitlines()
+        adjusted: list[str] = []
+        for line in tb_lines:
+            # Rewrite "File "<copy_anywhere_code>", line N" references
+            if "<copy_anywhere_code>" in line:
+                line = re.sub(
+                    r"line (\d+)",
+                    lambda m: f"line {max(1, int(m.group(1)) - 1)}",
+                    line,
+                )
+            adjusted.append(line)
+        # Drop the outer frame that points into execute_code.py itself
+        # (the first two lines are "Traceback..." + the exec() call site)
+        error_msg = "\n".join(adjusted).replace(
+            'File "<copy_anywhere_code>"', "Code line"
+        )
+        return None, error_msg
+
+    result = exec_globals.get("_result", None)
+    if result is None:
+        return None, None
+    return str(result), None

--- a/logic/interpolate_fields.py
+++ b/logic/interpolate_fields.py
@@ -1,21 +1,18 @@
+import json
 import re
 import time
 from functools import partial
-from typing import Tuple, Union, List, Optional, Callable, Sequence, cast
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union, cast
 
 from anki.cards import Card, CardId
-
 from anki.consts import (
-    CARD_TYPE_NEW,
     CARD_TYPE_LRN,
-    CARD_TYPE_REV,
+    CARD_TYPE_NEW,
     CARD_TYPE_RELEARNING,
+    CARD_TYPE_REV,
 )
-
 from anki.notes import Note
-
 from aqt import mw
-
 
 from ..utils.to_lowercase_dict import to_lowercase_dict
 
@@ -63,6 +60,8 @@ CARD_LAPSE_COUNT = "__Card_Lapse_Count"
 CARD_AVERAGE_TIME = "__Card_Average_Time"
 CARD_TOTAL_TIME = "__Card_Total_Time"
 CARD_CUSTOM_DATA = "__Card_Custom_Data"
+# Special value that takes an argument for a custom data property
+CARD_CUSTOM_DATA_PROP = f"__Card_Custom_Data_Prop{ARG_SEPARATOR}"
 CARD_TYPE = "__Card_Type"
 
 # A special value that takes an argument for how many reps to retrieve
@@ -91,6 +90,7 @@ CARD_VALUES = [
     CARD_AVERAGE_TIME,
     CARD_TOTAL_TIME,
     CARD_CUSTOM_DATA,
+    CARD_CUSTOM_DATA_PROP,
     CARD_TYPE,
     CARD_LAST_EASES,
     CARD_LAST_FACTORS,
@@ -172,7 +172,9 @@ BASE_NOTE_MENU_DICT = {
 DESTINATION_NOTE_MENU_DICT = {
     # The note being used to query
     DESTINATION_NOTE_DATA_KEY: {
-        "Destination Note Type ID (mid:)": intr_format(f"{DESTINATION_PREFIX}{NOTE_TYPE_ID}"),
+        "Destination Note Type ID (mid:)": intr_format(
+            f"{DESTINATION_PREFIX}{NOTE_TYPE_ID}"
+        ),
         "Destination Note ID (nid:)": intr_format(f"{DESTINATION_PREFIX}{NOTE_ID}"),
         "Destination note all tags": intr_format(f"{DESTINATION_PREFIX}{NOTE_TAGS}"),
         "Destination note has tag": intr_format(f"{DESTINATION_PREFIX}{NOTE_HAS_TAG}"),
@@ -192,7 +194,9 @@ JSONSerializableValue = Union[
     Sequence["JSONSerializableValue"],
     dict[str, "JSONSerializableValue"],
 ]
-ValueOrValueGetter = Union[JSONSerializableValue, Callable[[str], JSONSerializableValue]]
+ValueOrValueGetter = Union[
+    JSONSerializableValue, Callable[[str], JSONSerializableValue]
+]
 
 
 def get_note_data_value(
@@ -287,6 +291,18 @@ def get_card_last_reps(
 ValuesDict = dict[str, ValueOrValueGetter]
 
 
+def get_card_custom_data_prop(custom_data_str: str, prop: str) -> Any:
+    if not custom_data_str:
+        return ""
+    try:
+        custom_data = json.loads(custom_data_str)
+        if not isinstance(custom_data, dict):
+            return ""
+        return custom_data.get(prop, "")
+    except json.JSONDecodeError:
+        return ""
+
+
 def get_value_for_card(
     card: Card,
     note: Note,
@@ -307,13 +323,19 @@ def get_value_for_card(
         CARD_IVL: card.ivl or 0,
         CARD_EASE: card.factor / 10 or 0,
         # If FSRS is not enabled, memory_state will be None
-        CARD_STABILITY: round(card.memory_state.stability, 1) if card.memory_state else 0,
-        CARD_DIFFICULTY: round(card.memory_state.difficulty, 1) if card.memory_state else 0,
+        CARD_STABILITY: round(card.memory_state.stability, 1)
+        if card.memory_state
+        else 0,
+        CARD_DIFFICULTY: round(card.memory_state.difficulty, 1)
+        if card.memory_state
+        else 0,
         CARD_REP_COUNT: card.reps or 0,
         CARD_LAPSE_COUNT: card.lapses or 0,
         CARD_FIRST_REVIEW: format_timestamp(first / 1000) if first else "-",
         CARD_LATEST_REVIEW: format_timestamp(last / 1000) if last else "-",
-        CARD_AVERAGE_TIME: timespan(total / float(cnt)) if cnt is not None and cnt > 0 else "-",
+        CARD_AVERAGE_TIME: timespan(total / float(cnt))
+        if cnt is not None and cnt > 0
+        else "-",
         CARD_TOTAL_TIME: timespan(total),
         CARD_TYPE: (
             "Review"
@@ -324,12 +346,15 @@ def get_value_for_card(
                 else (
                     "Learning"
                     if card.type == CARD_TYPE_LRN
-                    else "Relearning" if card.type == CARD_TYPE_RELEARNING else ""
+                    else "Relearning"
+                    if card.type == CARD_TYPE_RELEARNING
+                    else ""
                 )
             )
         ),
         CARD_CREATED: format_timestamp(card.nid / 1000) if card.nid else "-",
         CARD_CUSTOM_DATA: card.custom_data or {},
+        CARD_CUSTOM_DATA_PROP: partial(get_card_custom_data_prop, card.custom_data),
         CARD_LAST_EASES: partial(get_card_last_reps, card.id, get_ease=True),
         CARD_LAST_FACTORS: partial(get_card_last_reps, card.id, get_fct=True),
         CARD_LAST_IVLS: partial(get_card_last_reps, card.id, get_ivl=True),
@@ -354,7 +379,9 @@ def get_card_values_dict_for_note(
     all_card_templates = note_type["tmpls"] if note_type else []
     # all cards will be empty for a new note being added
     # and some cards may be missing, if the template is conditional
-    template_names_with_current_card = {card.template()["name"] for card in current_cards}
+    template_names_with_current_card = {
+        card.template()["name"] for card in current_cards
+    }
     # For each card type that doesn't have a card yet, add default values
     for card_template in all_card_templates:
         if card_template["name"] not in template_names_with_current_card:
@@ -450,15 +477,17 @@ def get_from_note_fields(
             return value, card_values_dict
     # And last, cards are harder since they need to specify the card type name too
     card_match = (
-        CARD_VALUE_RE.match(field) if not multiple_note_types else MULTI_CARD_VALUE_RE.match(field)
+        CARD_VALUE_RE.match(field)
+        if not multiple_note_types
+        else MULTI_CARD_VALUE_RE.match(field)
     )
     if card_match:
         if multiple_note_types:
             maybe_card_value_key, maybe_card_value_arg = card_match.group(1, 2)
             maybe_card_type_name = ""
         else:
-            maybe_card_type_name, maybe_card_value_key, maybe_card_value_arg = card_match.group(
-                1, 2, 3
+            maybe_card_type_name, maybe_card_value_key, maybe_card_value_arg = (
+                card_match.group(1, 2, 3)
             )
         # Check if the card type name is valid
         if maybe_card_value_key in CARD_VALUES_DICT:

--- a/ui/card_actions_editor.py
+++ b/ui/card_actions_editor.py
@@ -13,6 +13,8 @@ from aqt.qt import (
     QComboBox,
     QButtonGroup,
     QRadioButton,
+    QDoubleSpinBox,
+    QLineEdit,
     qtmajor,
 )
 
@@ -265,6 +267,7 @@ class CardActionsEditor(QWidget):
             "set_flag": None,
             "suspend": None,
             "bury": None,
+            "set_desired_retention": None,
         }
 
         self.card_actions[card_type_name] = new_action
@@ -400,6 +403,50 @@ class CardActionsEditor(QWidget):
 
         form_layout.addRow(QLabel("<b>Bury card:</b>"), bury_layout)
 
+        # 5. Set desired retention
+        dr_layout = QHBoxLayout()
+
+        dr_number_input = QDoubleSpinBox()
+        dr_number_input.setRange(0.0, 0.99)
+        dr_number_input.setSingleStep(0.01)
+        dr_number_input.setDecimals(2)
+        dr_number_input.setSpecialValueText(" ")  # display blank when value is 0.0 (unset)
+        dr_number_input.setValue(0.0)
+
+        dr_string_input = QLineEdit()
+        dr_string_input.setPlaceholderText("Custom data property name")
+
+        # Load existing value
+        current_dr = action.get("set_desired_retention")
+        if isinstance(current_dr, (float, int)) and not isinstance(current_dr, bool):
+            dr_number_input.setValue(float(current_dr))
+        elif isinstance(current_dr, str) and current_dr:
+            dr_string_input.setText(current_dr)
+
+        # Mutual-clear: editing number clears string, editing string clears number
+        def _dr_number_changed(value, _string_input=dr_string_input, _number_input=dr_number_input):
+            if value >= 0.01:
+                _string_input.blockSignals(True)
+                _string_input.clear()
+                _string_input.blockSignals(False)
+
+        def _dr_string_changed(text, _number_input=dr_number_input):
+            if text:
+                _number_input.blockSignals(True)
+                _number_input.setValue(0.0)
+                _number_input.blockSignals(False)
+
+        dr_number_input.valueChanged.connect(_dr_number_changed)
+        dr_string_input.textChanged.connect(_dr_string_changed)
+
+        dr_layout.addWidget(QLabel("Float (0.01–0.99):"))
+        dr_layout.addWidget(dr_number_input)
+        dr_layout.addWidget(QLabel("or custom data property:"))
+        dr_layout.addWidget(dr_string_input)
+        dr_layout.addStretch()
+
+        form_layout.addRow(QLabel("<b>Set desired retention:</b>"), dr_layout)
+
         # Delete button
         delete_button = QPushButton("Delete this card action")
         delete_button.clicked.connect(lambda: self.delete_action(card_type_name))
@@ -412,6 +459,8 @@ class CardActionsEditor(QWidget):
             "flag_group": flag_group,
             "suspend_group": suspend_group,
             "bury_group": bury_group,
+            "dr_number_input": dr_number_input,
+            "dr_string_input": dr_string_input,
         }
 
     def save_action(self, card_type_name: str):
@@ -424,6 +473,8 @@ class CardActionsEditor(QWidget):
         flag_group = ui_components["flag_group"]
         suspend_group = ui_components["suspend_group"]
         bury_group = ui_components["bury_group"]
+        dr_number_input = ui_components["dr_number_input"]
+        dr_string_input = ui_components["dr_string_input"]
 
         # Get change_deck value
         deck_text = deck_combo.currentText()
@@ -450,6 +501,16 @@ class CardActionsEditor(QWidget):
                 bury = button.property("bury_value")
                 break
 
+        # Get set_desired_retention value (string input takes priority if non-empty)
+        dr_string = dr_string_input.text().strip()
+        dr_number = dr_number_input.value()
+        if dr_string:
+            set_desired_retention = dr_string
+        elif dr_number >= 0.01:
+            set_desired_retention = dr_number
+        else:
+            set_desired_retention = None
+
         # Update the action
         self.card_actions[card_type_name] = {
             "guid": self.card_actions[card_type_name].get("guid", str(uuid.uuid4())),
@@ -458,6 +519,7 @@ class CardActionsEditor(QWidget):
             "set_flag": set_flag,
             "suspend": suspend,
             "bury": bury,
+            "set_desired_retention": set_desired_retention,
         }
 
     def delete_action(self, card_type_name: str):
@@ -491,6 +553,7 @@ class CardActionsEditor(QWidget):
                 or action.get("set_flag") is not None
                 or action.get("suspend") is not None
                 or action.get("bury") is not None
+                or action.get("set_desired_retention") is not None
             ):
                 result.append(action)
 

--- a/ui/code_edit_layout.py
+++ b/ui/code_edit_layout.py
@@ -1,0 +1,229 @@
+"""A code-editing layout widget parallel to InterpolatedTextEditLayout.
+
+Differences from the text editor:
+  - Monospace font with 4-space tab stops.
+  - Live Python syntax validation: the user code is wrapped in a dummy
+    ``def`` so that ``return`` statements are syntactically valid at parse
+    time.  ``SyntaxError`` / ``IndentationError`` messages are shown inline.
+  - The same ``{{field}}`` interpolation-marker validation as the text editor.
+  - A persistent security notice and available-names reference.
+
+Public interface mirrors ``InterpolatedTextEditLayout`` so the two widgets can
+be swapped in host editors without touching surrounding code:
+  ``get_text()`` / ``set_text()`` / ``update_options()`` / ``validate_text()``
+"""
+
+import ast
+import textwrap
+from typing import Optional
+
+from aqt.qt import (
+    QFont,
+    QFontMetrics,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+    qtmajor,
+)
+
+from .pasteable_text_edit import PasteableTextEdit
+from ..logic.interpolate_fields import (
+    ARG_SEPARATOR,
+    ARG_VALIDATORS,
+    CARD_VALUE_RE,
+    NOTE_VALUE_RE,
+    basic_arg_validator,
+    get_fields_from_text,
+    intr_format,
+)
+
+_SECURITY_NOTICE = (
+    "⚠ <b>Code mode</b> — write the body of a function that <b>returns a string</b>. "
+    "<tt>{{Field}}</tt> markers are resolved before execution.<br>"
+    "Available names: <tt>re</tt>, <tt>json</tt>, <tt>find_cards</tt>, "
+    "<tt>find_notes</tt>, <tt>note</tt>. "
+    "<small>Built-ins are restricted to a safe subset.</small><br>"
+    "<small>⚠ Fields containing HTML (quotes, tags) can break string literals — "
+    "prefer <tt>note[\"Field Name\"]</tt> over <tt>\"{{Field Name}}\"</tt>.</small>"
+)
+
+
+class CodeEditLayout(QWidget):
+    """Monospace code editor with Python syntax + interpolation validation.
+
+    Designed to be a drop-in partner to ``InterpolatedTextEditLayout``: both
+    share ``get_text()`` / ``set_text()`` / ``update_options()`` so the host
+    editor can switch between them without special-casing.
+    """
+
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        options_dict: Optional[dict] = None,
+        is_required: bool = False,
+        label: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        super().__init__(parent)
+
+        self._validate_dict: dict = {}
+        self._options_dict: dict = options_dict or {}
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        # --- Header label (mirrors InterpolatedTextEditLayout) ---------------
+        self._label_widget = QLabel()
+        layout.addWidget(self._label_widget)
+        self.set_label(label)
+
+        # --- Security / context notice -------------------------------------------
+        self._notice_label = QLabel(_SECURITY_NOTICE)
+        self._notice_label.setWordWrap(True)
+        self._notice_label.setStyleSheet(
+            "color: #ddd;"
+            "border: 1px solid #ccc;"
+            "border-radius: 4px;"
+            "padding: 5px;"
+            "font-size: 10px;"
+        )
+        layout.addWidget(self._notice_label)
+
+        # --- Interpolation description (mirrors InterpolatedTextEditLayout) --
+        self._description_label = QLabel()
+        self._description_label.setWordWrap(True)
+        self._description_label.setStyleSheet("font-size: 10px;")
+        layout.addWidget(self._description_label)
+        self.set_description(description)
+
+        # --- Code editor ---------------------------------------------------------
+        self.text_edit = PasteableTextEdit(
+            parent=self,
+            options_dict=self._options_dict,
+            is_required=is_required,
+            placeholder_text="return ...",
+        )
+        self._apply_code_font()
+        self.text_edit.textChanged.connect(self.validate_text)
+        layout.addWidget(self.text_edit)
+
+        # --- Error / validation label --------------------------------------------
+        self.error_label = QLabel()
+        self.error_label.setWordWrap(True)
+        layout.addWidget(self.error_label)
+
+    # -------------------------------------------------------------------------
+    # Font / appearance
+    # -------------------------------------------------------------------------
+
+    def _apply_code_font(self) -> None:
+        font = QFont("Courier New")
+        if qtmajor > 5:
+            font.setStyleHint(QFont.StyleHint.Monospace)
+        else:
+            font.setStyleHint(QFont.Monospace)  # type: ignore[attr-defined]
+        font.setPointSize(10)
+        self.text_edit.setFont(font)
+        tab_px = QFontMetrics(font).horizontalAdvance("    ")
+        self.text_edit.setTabStopDistance(float(tab_px))
+
+    # -------------------------------------------------------------------------
+    # Public interface (mirrors InterpolatedTextEditLayout)
+    # -------------------------------------------------------------------------
+
+    def get_text(self) -> str:
+        return self.text_edit.toPlainText()
+
+    def set_text(self, text: str) -> None:
+        self.text_edit.setPlainText(text)
+        self.text_edit.update_required_style()
+
+    def set_label(self, label: Optional[str]) -> None:
+        if label:
+            self._label_widget.setText(label)
+            self._label_widget.show()
+        else:
+            self._label_widget.hide()
+
+    def set_description(self, description: Optional[str]) -> None:
+        if description:
+            self._description_label.setText(description)
+            self._description_label.show()
+        else:
+            self._description_label.hide()
+
+    def update_options(
+        self, new_options_dict: dict, new_validate_dict: dict
+    ) -> None:
+        self.text_edit.clear_options()
+        self._options_dict = new_options_dict
+        self._validate_dict = new_validate_dict
+        self.text_edit.set_options_dict(new_options_dict)
+        self.validate_text()
+
+    # -------------------------------------------------------------------------
+    # Validation
+    # -------------------------------------------------------------------------
+
+    def validate_text(self) -> None:
+        code = self.text_edit.toPlainText()
+        errors: list[str] = []
+
+        # 1. Python syntax check (wrap in a def so ``return`` is legal at parse
+        #    time; shift reported line numbers back by 1 to account for the
+        #    injected ``def`` line).
+        if code.strip():
+            wrapped = "def _user_func():\n" + textwrap.indent(
+                code if code else " ", "    "
+            )
+            try:
+                ast.parse(wrapped)
+            except SyntaxError as e:
+                user_line = max(1, (e.lineno or 1) - 1)
+                kind = (
+                    "Indentation error"
+                    if isinstance(e, IndentationError)
+                    else "Syntax error"
+                )
+                errors.append(
+                    f'<b style="color:red">{kind}</b> (line {user_line}): {e.msg}'
+                )
+
+        # 2. {{field}} interpolation-marker validation (same logic as
+        #    InterpolatedTextEditLayout.validate_text()).
+        fields = get_fields_from_text(code)
+        for field in fields:
+            arg: Optional[str] = None
+            card_type_name: Optional[str] = None
+            if ARG_SEPARATOR in field and "__" in field:
+                m = NOTE_VALUE_RE.match(field)
+                if m:
+                    field, arg = m.group(1, 2)
+                else:
+                    m = CARD_VALUE_RE.match(field)
+                    if m:
+                        card_type_name, field, arg = m.group(1, 2, 3)
+                        field = card_type_name + field
+
+            try:
+                self._validate_dict[intr_format(field.lower())]
+            except KeyError:
+                errors.append(
+                    f'<b style="color:red">{field}</b>: Not a valid field'
+                )
+                continue
+
+            if arg is not None:
+                key = field[len(card_type_name) :] if card_type_name else field
+                validator = ARG_VALIDATORS.get(key, None)
+                if validator is not None:
+                    error_msg = basic_arg_validator(arg) or validator(arg)
+                    if error_msg:
+                        errors.append(
+                            f'{field} <span style="color: orange;">'
+                            f'<b style="color:red">{arg or "[blank]"}</b>'
+                            f": {error_msg}</span>"
+                        )
+
+        self.error_label.setText("<br/>".join(errors) if errors else "")

--- a/ui/code_edit_layout.py
+++ b/ui/code_edit_layout.py
@@ -40,8 +40,8 @@ from ..logic.interpolate_fields import (
 _SECURITY_NOTICE = (
     "⚠ <b>Code mode</b> — write the body of a function that <b>returns a string</b>. "
     "<tt>{{Field}}</tt> markers are resolved before execution.<br>"
-    "Available names: <tt>re</tt>, <tt>json</tt>, <tt>find_cards</tt>, "
-    "<tt>find_notes</tt>, <tt>note</tt>. "
+    "Available names: <tt>re</tt>, <tt>json</tt>, <tt>html</tt>, <tt>print</tt>, "
+    "<tt>find_cards</tt>, <tt>find_notes</tt>, <tt>note</tt>. "
     "<small>Built-ins are restricted to a safe subset.</small><br>"
     "<small>⚠ Fields containing HTML (quotes, tags) can break string literals — "
     "prefer <tt>note[\"Field Name\"]</tt> over <tt>\"{{Field Name}}\"</tt>.</small>"

--- a/ui/copy_field_to_field_editor.py
+++ b/ui/copy_field_to_field_editor.py
@@ -36,6 +36,8 @@ from .multi_combo_box import MultiComboBox
 from .grouped_combo_box import GroupedComboBox
 from .edit_extra_processing_dialog import EditExtraProcessingWidget
 from .interpolated_text_edit import InterpolatedTextEditLayout
+from .code_edit_layout import CodeEditLayout
+from .toggle_switch import ToggleSwitch
 from ..logic.interpolate_fields import (
     BASE_NOTE_MENU_DICT,
     DESTINATION_PREFIX,
@@ -59,6 +61,9 @@ class FieldInputsDict(TypedDict):
     target_note_field_label: QLabel
     copy_from_text_label: QLabel
     copy_from_text: InterpolatedTextEditLayout
+    text_mode_container: QWidget
+    use_code: ToggleSwitch
+    copy_as_code: CodeEditLayout
     copy_if_empty: QCheckBox
     copy_on_unfocus_when_edit: QCheckBox
     copy_on_unfocus_when_add: QCheckBox
@@ -158,6 +163,8 @@ class CopyFieldToFieldEditor(QWidget):
             "guid": str(uuid.uuid4()),
             "copy_into_note_field": "",
             "copy_from_text": "",
+            "copy_as_code": "",
+            "use_code": False,
             "copy_if_empty": False,
             "copy_on_unfocus_when_edit": False,
             "copy_on_unfocus_when_add": False,
@@ -219,7 +226,8 @@ class CopyFieldToFieldEditor(QWidget):
             field_target_cbox.setCurrentText(copy_field_to_field_definition["copy_into_note_field"])
             field_target_cbox.update_required_style()
 
-        # Copy from field
+        # Copy from field — wrap in a container widget so it can be hidden when
+        # the user switches to code mode without losing the entered text.
         copy_from_text_label = QLabel(
             # Default to within mode texts, these only need to be modifed in across mode
             "<h3>Trigger note fields' content that will replace the field</h3>"
@@ -236,14 +244,22 @@ class CopyFieldToFieldEditor(QWidget):
         <li>There are many other data values you can use, such as the
             {intr_format(NOTE_ID)}, {intr_format(CARD_IVL)}, {intr_format(CARD_TYPE)} etc.</li>
         </ul>"""
+
+        # Code mode toggle — placed first so it stays above whichever editor is shown
+        use_code_checkbox = ToggleSwitch("Execute content as Python code")
+        row_form.addRow(use_code_checkbox)
+
+        text_mode_container = QWidget()
+        text_mode_vbox = QVBoxLayout(text_mode_container)
+        text_mode_vbox.setContentsMargins(0, 0, 0, 0)
         copy_from_text_layout = InterpolatedTextEditLayout(
             is_required=True,
             label=copy_from_text_label,
             options_dict=get_new_base_dict(self.copy_mode),
             description=copy_from_text_description,
         )
-
-        row_form.addRow(copy_from_text_layout)
+        text_mode_vbox.addLayout(copy_from_text_layout)
+        row_form.addRow(text_mode_container)
 
         copy_from_text_layout.update_options(
             self.state.post_query_menu_options_dict,
@@ -251,6 +267,43 @@ class CopyFieldToFieldEditor(QWidget):
         )
         with suppress(KeyError):
             copy_from_text_layout.set_text(copy_field_to_field_definition["copy_from_text"])
+
+        # Code editor (hidden while text mode is active)
+        copy_as_code_widget = CodeEditLayout(
+            parent=self,
+            options_dict=get_new_base_dict(self.copy_mode),
+            is_required=False,
+            label=copy_from_text_label.text(),
+            description=copy_from_text_description,
+        )
+        copy_as_code_widget.hide()
+        row_form.addRow(copy_as_code_widget)
+
+        copy_as_code_widget.update_options(
+            self.state.post_query_menu_options_dict,
+            self.state.post_query_text_edit_validate_dict,
+        )
+        with suppress(KeyError):
+            saved_code = copy_field_to_field_definition.get("copy_as_code", "")
+            if saved_code:
+                copy_as_code_widget.set_text(saved_code)
+
+        # Apply initial mode and wire toggle
+        initial_use_code = copy_field_to_field_definition.get("use_code", False)
+        if initial_use_code:
+            use_code_checkbox.setChecked(True)
+            text_mode_container.hide()
+            copy_as_code_widget.show()
+
+        def on_use_code_toggled(checked: bool):
+            text_mode_container.setVisible(not checked)
+            copy_as_code_widget.setVisible(checked)
+            if checked and not copy_as_code_widget.get_text().strip():
+                copy_as_code_widget.set_text(
+                    f"return {repr(copy_from_text_layout.get_text())}"
+                )
+
+        use_code_checkbox.toggled.connect(on_use_code_toggled)
 
         copy_if_empty = QCheckBox("Only copy into field, if it's empty")
         row_form.addRow("", copy_if_empty)
@@ -307,6 +360,9 @@ class CopyFieldToFieldEditor(QWidget):
             "target_note_field_label": target_note_field_label,
             "copy_from_text_label": copy_from_text_label,
             "copy_from_text": copy_from_text_layout,
+            "text_mode_container": text_mode_container,
+            "use_code": use_code_checkbox,
+            "copy_as_code": copy_as_code_widget,
             "copy_if_empty": copy_if_empty,
             "copy_on_unfocus_trigger_label": copy_on_unfocus_trigger_label,
             "copy_on_unfocus_trigger_field": copy_on_unfocus_trigger_field,
@@ -377,6 +433,8 @@ class CopyFieldToFieldEditor(QWidget):
             copy_field_definition = {
                 "copy_into_note_field": copy_field_inputs["copy_into_note_field"].currentText(),
                 "copy_from_text": copy_field_inputs["copy_from_text"].get_text(),
+                "copy_as_code": copy_field_inputs["copy_as_code"].get_text(),
+                "use_code": copy_field_inputs["use_code"].isChecked(),
                 "copy_if_empty": copy_field_inputs["copy_if_empty"].isChecked(),
                 "copy_on_unfocus_when_edit": (
                     copy_field_inputs["copy_on_unfocus_when_edit"].isChecked()
@@ -402,6 +460,10 @@ class CopyFieldToFieldEditor(QWidget):
                 self.state.post_query_menu_options_dict,
                 self.state.post_query_text_edit_validate_dict,
             )
+            copy_field_inputs["copy_as_code"].update_options(
+                self.state.post_query_menu_options_dict,
+                self.state.post_query_text_edit_validate_dict,
+            )
 
     def update_direction_labels(self):
         if self.state.copy_direction == DIRECTION_DESTINATION_TO_SOURCES:
@@ -422,6 +484,7 @@ class CopyFieldToFieldEditor(QWidget):
             target_note_field_label.setText(new_copy_into_label)
             copy_from_text_label = cast(QLabel, copy_field_inputs["copy_from_text_label"])
             copy_from_text_label.setText(new_copy_from_text_label)
+            copy_field_inputs["copy_as_code"].set_label(new_copy_from_text_label)
             # Copy on unfocus when adding is not allowed when source to destination, disable it
             copy_on_unfocus_when_add = cast(
                 QCheckBox, copy_field_inputs["copy_on_unfocus_when_add"]

--- a/ui/copy_field_to_file_editor.py
+++ b/ui/copy_field_to_file_editor.py
@@ -35,6 +35,8 @@ from ..configuration import (
 from .multi_combo_box import MultiComboBox
 from .edit_extra_processing_dialog import EditExtraProcessingWidget
 from .interpolated_text_edit import InterpolatedTextEditLayout
+from .code_edit_layout import CodeEditLayout
+from .toggle_switch import ToggleSwitch
 from ..logic.interpolate_fields import (
     BASE_NOTE_MENU_DICT,
     DESTINATION_PREFIX,
@@ -57,6 +59,9 @@ class FieldInputsDict(TypedDict):
     copy_into_filename: InterpolatedTextEditLayout
     copy_from_text_label: QLabel
     copy_from_text: InterpolatedTextEditLayout
+    text_mode_container: QWidget
+    use_code: ToggleSwitch
+    copy_as_code: CodeEditLayout
     copy_if_empty: QCheckBox
     copy_on_unfocus_when_edit: QCheckBox
     copy_on_unfocus_when_add: QCheckBox
@@ -150,6 +155,8 @@ class CopyFieldToFileEditor(QWidget):
             "guid": str(uuid.uuid4()),
             "copy_into_filename": "",
             "copy_from_text": "",
+            "copy_as_code": "",
+            "use_code": False,
             "copy_if_empty": False,
             "copy_on_unfocus_when_edit": False,
             "copy_on_unfocus_when_add": False,
@@ -203,7 +210,8 @@ class CopyFieldToFileEditor(QWidget):
         with suppress(KeyError):
             filename_text_layout.set_text(copy_field_to_field_definition["copy_into_filename"])
 
-        # Copy from field
+        # Copy from field — wrap in a container widget so it can be hidden when
+        # the user switches to code mode without losing the entered text.
         copy_from_text_label = QLabel(
             # Default to within mode texts, these only need to be modifed in across mode
             "<h3>Trigger note fields' content to write to file</h3>"
@@ -220,14 +228,22 @@ class CopyFieldToFileEditor(QWidget):
         <li>There are many other data values you can use, such as the
             {intr_format(NOTE_ID)}, {intr_format(CARD_IVL)}, {intr_format(CARD_TYPE)} etc.</li>
         </ul>"""
+
+        # Code mode toggle — placed first so it stays above whichever editor is shown
+        use_code_checkbox = ToggleSwitch("Execute content as Python code")
+        row_form.addRow(use_code_checkbox)
+
+        text_mode_container = QWidget()
+        text_mode_vbox = QVBoxLayout(text_mode_container)
+        text_mode_vbox.setContentsMargins(0, 0, 0, 0)
         copy_from_text_layout = InterpolatedTextEditLayout(
             is_required=True,
             label=copy_from_text_label,
             options_dict=get_new_base_dict(self.copy_mode),
             description=copy_from_text_description,
         )
-
-        row_form.addRow(copy_from_text_layout)
+        text_mode_vbox.addLayout(copy_from_text_layout)
+        row_form.addRow(text_mode_container)
 
         copy_from_text_layout.update_options(
             self.state.post_query_menu_options_dict,
@@ -235,6 +251,43 @@ class CopyFieldToFileEditor(QWidget):
         )
         with suppress(KeyError):
             copy_from_text_layout.set_text(copy_field_to_field_definition["copy_from_text"])
+
+        # Code editor (hidden while text mode is active)
+        copy_as_code_widget = CodeEditLayout(
+            parent=self,
+            options_dict=get_new_base_dict(self.copy_mode),
+            is_required=False,
+            label=copy_from_text_label.text(),
+            description=copy_from_text_description,
+        )
+        copy_as_code_widget.hide()
+        row_form.addRow(copy_as_code_widget)
+
+        copy_as_code_widget.update_options(
+            self.state.post_query_menu_options_dict,
+            self.state.post_query_text_edit_validate_dict,
+        )
+        with suppress(KeyError):
+            saved_code = copy_field_to_field_definition.get("copy_as_code", "")
+            if saved_code:
+                copy_as_code_widget.set_text(saved_code)
+
+        # Apply initial mode and wire toggle
+        initial_use_code = copy_field_to_field_definition.get("use_code", False)
+        if initial_use_code:
+            use_code_checkbox.setChecked(True)
+            text_mode_container.hide()
+            copy_as_code_widget.show()
+
+        def on_use_code_toggled(checked: bool):
+            text_mode_container.setVisible(not checked)
+            copy_as_code_widget.setVisible(checked)
+            if checked and not copy_as_code_widget.get_text().strip():
+                copy_as_code_widget.set_text(
+                    f"return {repr(copy_from_text_layout.get_text())}"
+                )
+
+        use_code_checkbox.toggled.connect(on_use_code_toggled)
 
         copy_if_empty = QCheckBox("Only write to file, if it doesn't exist")
         row_form.addRow("", copy_if_empty)
@@ -285,6 +338,9 @@ class CopyFieldToFileEditor(QWidget):
             "copy_into_filename": filename_text_layout,
             "copy_from_text_label": copy_from_text_label,
             "copy_from_text": copy_from_text_layout,
+            "text_mode_container": text_mode_container,
+            "use_code": use_code_checkbox,
+            "copy_as_code": copy_as_code_widget,
             "copy_if_empty": copy_if_empty,
             "copy_on_unfocus_trigger_label": copy_on_unfocus_trigger_label,
             "copy_on_unfocus_trigger_field": copy_on_unfocus_trigger_field,
@@ -355,6 +411,8 @@ class CopyFieldToFileEditor(QWidget):
             copy_field_definition = {
                 "copy_into_filename": copy_field_inputs["copy_into_filename"].get_text(),
                 "copy_from_text": copy_field_inputs["copy_from_text"].get_text(),
+                "copy_as_code": copy_field_inputs["copy_as_code"].get_text(),
+                "use_code": copy_field_inputs["use_code"].isChecked(),
                 "copy_if_empty": copy_field_inputs["copy_if_empty"].isChecked(),
                 "copy_on_unfocus_when_edit": (
                     copy_field_inputs["copy_on_unfocus_when_edit"].isChecked()
@@ -383,6 +441,10 @@ class CopyFieldToFileEditor(QWidget):
                 self.state.post_query_menu_options_dict,
                 self.state.post_query_text_edit_validate_dict,
             )
+            copy_field_inputs["copy_as_code"].update_options(
+                self.state.post_query_menu_options_dict,
+                self.state.post_query_text_edit_validate_dict,
+            )
 
     def update_direction_labels(self, _):
         if self.state.copy_direction == DIRECTION_DESTINATION_TO_SOURCES:
@@ -398,6 +460,7 @@ class CopyFieldToFileEditor(QWidget):
         for copy_field_inputs in self.copy_field_inputs:
             copy_from_text_label = cast(QLabel, copy_field_inputs["copy_from_text_label"])
             copy_from_text_label.setText(new_copy_from_text_label)
+            copy_field_inputs["copy_as_code"].set_label(new_copy_from_text_label)
             # Copy on unfocus when adding is not allowed when source to destination, disable it
             copy_on_unfocus_when_add = cast(
                 QCheckBox, copy_field_inputs["copy_on_unfocus_when_add"]

--- a/ui/edit_copy_definition_dialog.py
+++ b/ui/edit_copy_definition_dialog.py
@@ -1214,7 +1214,10 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
             if field_to_field_definition["copy_into_note_field"] == "":
                 missing_copy_into_error = "Destination field cannot be empty."
                 show_error = True
-            if field_to_field_definition["copy_from_text"] == "":
+            if (
+                field_to_field_definition["copy_from_text"] == ""
+                and field_to_field_definition.get("copy_as_code", "") == ""
+            ):
                 missing_copy_from_error = "Copied content cannot be empty."
                 show_error = True
 

--- a/ui/edit_copy_definition_dialog.py
+++ b/ui/edit_copy_definition_dialog.py
@@ -1214,13 +1214,18 @@ class EditCopyDefinitionDialog(ScrollableQDialog):
             if field_to_field_definition["copy_into_note_field"] == "":
                 missing_copy_into_error = "Destination field cannot be empty."
                 show_error = True
-            if (
-                field_to_field_definition["copy_from_text"] == ""
-                and field_to_field_definition.get("copy_as_code", "") == ""
-            ):
-                missing_copy_from_error = "Copied content cannot be empty."
-                show_error = True
 
+            use_code = field_to_field_definition.get("use_code", False)
+            if use_code:
+                # When using code, require copy_as_code to be non-empty, regardless of copy_from_text
+                if field_to_field_definition.get("copy_as_code", "") == "":
+                    missing_copy_from_error = "Copied content cannot be empty."
+                    show_error = True
+            else:
+                # When not using code, require copy_from_text to be non-empty, regardless of copy_as_code
+                if field_to_field_definition.get("copy_from_text", "") == "":
+                    missing_copy_from_error = "Copied content cannot be empty."
+                    show_error = True
         if self.state.definition_name is None or self.state.definition_name == "":
             missing_name_error = "Definition name cannot be empty."
             show_error = True

--- a/ui/field_to_variable_editor.py
+++ b/ui/field_to_variable_editor.py
@@ -8,7 +8,6 @@ from aqt.qt import (
     QFrame,
     QFormLayout,
     QPushButton,
-    QCheckBox,
     qtmajor,
 )
 

--- a/ui/field_to_variable_editor.py
+++ b/ui/field_to_variable_editor.py
@@ -8,6 +8,7 @@ from aqt.qt import (
     QFrame,
     QFormLayout,
     QPushButton,
+    QCheckBox,
     qtmajor,
 )
 
@@ -23,6 +24,8 @@ else:
 
 from .edit_extra_processing_dialog import EditExtraProcessingWidget
 from .interpolated_text_edit import InterpolatedTextEditLayout
+from .code_edit_layout import CodeEditLayout
+from .toggle_switch import ToggleSwitch
 from ..logic.interpolate_fields import (
     BASE_NOTE_MENU_DICT,
     NOTE_ID,
@@ -37,6 +40,9 @@ from .edit_state import EditState
 class VariableInputsDict(TypedDict):
     copy_into_variable: RequiredLineEdit
     copy_from_text: InterpolatedTextEditLayout
+    text_mode_container: QWidget
+    use_code: ToggleSwitch
+    copy_as_code: CodeEditLayout
     process_chain: EditExtraProcessingWidget
 
 
@@ -131,6 +137,8 @@ class CopyFieldToVariableEditor(QWidget):
             "guid": str(uuid.uuid4()),
             "copy_into_variable": "",
             "copy_from_text": "",
+            "copy_as_code": "",
+            "use_code": False,
             "process_chain": [],
         }
         self.fields_to_variable_defs.append(new_definition)
@@ -173,19 +181,30 @@ class CopyFieldToVariableEditor(QWidget):
 
         variable_name_field.textChanged.connect(self.update_variable_names_in_state)
 
-        # Copy from field
-        copy_from_text_layout = InterpolatedTextEditLayout(
-            is_required=True,
-            label="<h4>Trigger note's fields' content to store in the variable</h4>",
-            options_dict=BASE_NOTE_MENU_DICT.copy(),
-            description=f"""<ul>
+        copy_from_text_description = f"""<ul>
         <li>Reference the trigger note's fields with  {intr_format('Field Name')}.</li>
         <li>Right-click to select a  {intr_format('Field Name')} to paste</li>
         <li>There are many other data values you can use, such as the {intr_format(NOTE_ID)},
  {intr_format(CARD_IVL)}, {intr_format(CARD_TYPE)} etc.</li>
-        </ul>""",
+        </ul>"""
+
+        # Code mode toggle — placed first so it stays above whichever editor is shown
+        use_code_checkbox = ToggleSwitch("Execute content as Python code")
+        row_form.addRow(use_code_checkbox)
+
+        # Copy from field — wrap in a container widget so it can be hidden when
+        # the user switches to code mode without losing the entered text.
+        text_mode_container = QWidget()
+        text_mode_vbox = QVBoxLayout(text_mode_container)
+        text_mode_vbox.setContentsMargins(0, 0, 0, 0)
+        copy_from_text_layout = InterpolatedTextEditLayout(
+            is_required=True,
+            label="<h4>Trigger note's fields' content to store in the variable</h4>",
+            options_dict=BASE_NOTE_MENU_DICT.copy(),
+            description=copy_from_text_description,
         )
-        row_form.addRow(copy_from_text_layout)
+        text_mode_vbox.addLayout(copy_from_text_layout)
+        row_form.addRow(text_mode_container)
 
         copy_from_text_layout.update_options(
             self.state.pre_query_menu_options_dict,
@@ -193,6 +212,43 @@ class CopyFieldToVariableEditor(QWidget):
         )
         with suppress(KeyError):
             copy_from_text_layout.set_text(copy_field_to_variable_definition["copy_from_text"])
+
+        # Code editor (hidden while text mode is active)
+        copy_as_code_widget = CodeEditLayout(
+            parent=self,
+            options_dict=BASE_NOTE_MENU_DICT.copy(),
+            is_required=False,
+            label="<h4>Trigger note's fields' content to store in the variable</h4>",
+            description=copy_from_text_description,
+        )
+        copy_as_code_widget.hide()
+        row_form.addRow(copy_as_code_widget)
+
+        copy_as_code_widget.update_options(
+            self.state.pre_query_menu_options_dict,
+            self.state.pre_query_text_edit_validate_dict,
+        )
+        with suppress(KeyError):
+            saved_code = copy_field_to_variable_definition.get("copy_as_code", "")
+            if saved_code:
+                copy_as_code_widget.set_text(saved_code)
+
+        # Apply initial mode and wire toggle
+        initial_use_code = copy_field_to_variable_definition.get("use_code", False)
+        if initial_use_code:
+            use_code_checkbox.setChecked(True)
+            text_mode_container.hide()
+            copy_as_code_widget.show()
+
+        def on_use_code_toggled(checked: bool):
+            text_mode_container.setVisible(not checked)
+            copy_as_code_widget.setVisible(checked)
+            if checked and not copy_as_code_widget.get_text().strip():
+                copy_as_code_widget.set_text(
+                    f"return {repr(copy_from_text_layout.get_text())}"
+                )
+
+        use_code_checkbox.toggled.connect(on_use_code_toggled)
 
         # Extra processing
         process_chain_widget = EditExtraProcessingWidget(
@@ -211,6 +267,9 @@ class CopyFieldToVariableEditor(QWidget):
         copy_field_inputs_dict: VariableInputsDict = {
             "copy_into_variable": variable_name_field,
             "copy_from_text": copy_from_text_layout,
+            "text_mode_container": text_mode_container,
+            "use_code": use_code_checkbox,
+            "copy_as_code": copy_as_code_widget,
             "process_chain": process_chain_widget,
         }
 
@@ -287,6 +346,8 @@ class CopyFieldToVariableEditor(QWidget):
             copy_variable_definition = {
                 "copy_into_variable": copy_field_inputs["copy_into_variable"].text(),
                 "copy_from_text": copy_field_inputs["copy_from_text"].get_text(),
+                "copy_as_code": copy_field_inputs["copy_as_code"].get_text(),
+                "use_code": copy_field_inputs["use_code"].isChecked(),
                 "process_chain": copy_field_inputs["process_chain"].get_process_chain(),
             }
             field_to_field_defs.append(copy_variable_definition)
@@ -295,6 +356,10 @@ class CopyFieldToVariableEditor(QWidget):
     def update_variables_options_dicts(self):
         for copy_field_inputs in self.copy_field_inputs:
             copy_field_inputs["copy_from_text"].update_options(
+                self.state.pre_query_menu_options_dict,
+                self.state.pre_query_text_edit_validate_dict,
+            )
+            copy_field_inputs["copy_as_code"].update_options(
                 self.state.pre_query_menu_options_dict,
                 self.state.pre_query_text_edit_validate_dict,
             )

--- a/ui/toggle_switch.py
+++ b/ui/toggle_switch.py
@@ -1,0 +1,92 @@
+"""A custom toggle-switch widget for use in place of QCheckBox.
+
+Draws a rounded track with a sliding circular thumb — analogous to mobile
+toggle switches.  Exposes the same interface as a ``QCheckBox``:
+  - ``isChecked()``
+  - ``setChecked(bool)``
+  - ``toggled`` signal
+
+Usage::
+
+    switch = ToggleSwitch("Execute content as Python code")
+    switch.toggled.connect(my_slot)
+"""
+
+from aqt.qt import (
+    QAbstractButton,
+    QColor,
+    QFontMetrics,
+    QPainter,
+    QPen,
+    QRect,
+    QSize,
+    QSizePolicy,
+    Qt,
+    qtmajor,
+)
+
+if qtmajor > 5:
+    _PointingHand = Qt.CursorShape.PointingHandCursor
+    _Antialiasing = QPainter.RenderHint.Antialiasing
+    _NoPen = Qt.PenStyle.NoPen
+else:
+    _PointingHand = Qt.PointingHandCursor  # type: ignore[attr-defined]
+    _Antialiasing = QPainter.Antialiasing  # type: ignore[attr-defined]
+    _NoPen = Qt.NoPen  # type: ignore[attr-defined]
+
+_TRACK_W = 36
+_TRACK_H = 18
+_THUMB_D = 14  # diameter
+_THUMB_MARGIN = 2  # gap between thumb and track edge
+_GAP = 8  # pixels between track and label
+
+
+class ToggleSwitch(QAbstractButton):
+    """A painted toggle switch that behaves like a checkable QAbstractButton."""
+
+    def __init__(self, label: str = "", parent=None) -> None:
+        super().__init__(parent)
+        self.setCheckable(True)
+        self.setText(label)
+        self.setCursor(_PointingHand)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed if qtmajor > 5 else QSizePolicy.Fixed, QSizePolicy.Policy.Fixed if qtmajor > 5 else QSizePolicy.Fixed)  # type: ignore[attr-defined]
+
+    def sizeHint(self) -> QSize:
+        fm = QFontMetrics(self.font())
+        text_w = fm.horizontalAdvance(self.text()) if self.text() else 0
+        label_part = _GAP + text_w if text_w else 0
+        height = max(_TRACK_H, fm.height())
+        return QSize(_TRACK_W + label_part + 2, height + 4)
+
+    def paintEvent(self, _event) -> None:  # noqa: N802
+        p = QPainter(self)
+        p.setRenderHint(_Antialiasing)
+
+        h = self.height()
+        track_y = (h - _TRACK_H) // 2
+
+        # --- Track -----------------------------------------------------------
+        track_color = QColor("#4a86d9") if self.isChecked() else QColor("#aaaaaa")
+        p.setBrush(track_color)
+        p.setPen(_NoPen)
+        p.drawRoundedRect(QRect(0, track_y, _TRACK_W, _TRACK_H), _TRACK_H / 2, _TRACK_H / 2)
+
+        # --- Thumb -----------------------------------------------------------
+        thumb_y = track_y + _THUMB_MARGIN
+        if self.isChecked():
+            thumb_x = _TRACK_W - _THUMB_D - _THUMB_MARGIN
+        else:
+            thumb_x = _THUMB_MARGIN
+        p.setBrush(QColor("white"))
+        p.setPen(QPen(QColor("#cccccc"), 0.5))
+        p.drawEllipse(QRect(thumb_x, thumb_y, _THUMB_D, _THUMB_D))
+
+        # --- Label -----------------------------------------------------------
+        if self.text():
+            fm = QFontMetrics(self.font())
+            text_x = _TRACK_W + _GAP
+            text_y = (h + fm.ascent() - fm.descent()) // 2
+            p.setPen(QPen(self.palette().windowText().color()))
+            p.drawText(text_x, text_y, self.text())
+
+        p.end()


### PR DESCRIPTION
## New features

- Execute python code to make variables and new note field values. The code execution is meant to be limited for security as one dangerous thing you could do is interpolate in code from a note field which would open the addon up to code from decks made by somebody else
- New card action for setting `card.desired_retention`. Useful for controlling card backlog review order
- Bunch of non-relevant formatting changes because of Zed's default formatting being from different my setup on VS Code and didn't bother configuring it in anyway